### PR TITLE
feat: open-source readiness (RAI-6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,18 @@
 # Copy to .env in this repository root.
-# Databases are external (e.g. Neon); no local Postgres required for compose.
-# Replace the hostname after @ with your real Postgres host (do not use the word HOST alone — it is a valid-looking placeholder that breaks DNS).
+# Databases are external (e.g. Neon); no local Postgres container is defined in compose.
+# Replace the hostname after @ with your real Postgres host (do not use the literal word HOST — it is a valid-looking placeholder that breaks DNS).
 
 USERS_DATABASE_URL=postgresql://USER:PASSWORD@YOUR_POSTGRES_HOST:5432/users_db
 ACCOUNTS_DATABASE_URL=postgresql://USER:PASSWORD@YOUR_POSTGRES_HOST:5432/accounts_db
 LEDGER_DATABASE_URL=postgresql://USER:PASSWORD@YOUR_POSTGRES_HOST:5432/ledger_db
 
-# Optional
+# Optional — logging for Rust services in Docker Compose
 RUST_LOG=info
+
+# Optional — only when running Rust services on the host (not needed for `make dev`):
+# ACCOUNTS_GRPC_URL=http://127.0.0.1:9090
+# USERS_GRPC_URL=http://127.0.0.1:50051
+# LEDGER_GRPC_URL=http://127.0.0.1:50053
+
+# Optional — users-service sensitive routes (register/login) require this header when set:
+# INTERNAL_SERVICE_TOKEN_ALLOWLIST=your-dev-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUBY_VERSION: "3.3.0"
+
+jobs:
+  compose-config:
+    name: Docker Compose config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate compose file
+        env:
+          USERS_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/users_ci
+          ACCOUNTS_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/accounts_ci
+          LEDGER_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_ci
+        run: docker compose config --quiet
+
+  rust-users:
+    name: users-service (clippy, test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/users-service
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: services/users-service
+      - run: cargo clippy --locked --all-targets
+      - run: cargo test --locked
+
+  rust-accounts:
+    name: accounts-service (clippy, test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/accounts-service
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: services/accounts-service
+      - run: cargo clippy --locked --all-targets
+      - run: cargo test --locked
+
+  ledger-rails:
+    name: ledger-service (test)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    defaults:
+      run:
+        working-directory: services/ledger-service
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: services/ledger-service
+      - run: bundle exec rails db:test:prepare test
+
+  docker-builds:
+    name: Dockerfile build (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [users-service, accounts-service, ledger-service]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -f "services/${{ matrix.service }}/Dockerfile" "services/${{ matrix.service }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,40 @@ From each service directory, use the same commands CI uses:
 
 From the repository root, `make verify` checks that vendored service folders exist.
 
+## Branching (Gitflow)
+
+We follow **Gitflow**-style branching:
+
+- **`main`** — production-ready history; only merges from `release/*` or `hotfix/*`.
+- **`develop`** — day-to-day integration; default base for new work.
+- **`feature/*`** — branch from `develop` for new work (for example `feature/rai-6-open-source-readiness`). Open a PR back into `develop`.
+- **`release/*`** — branch from `develop` when cutting a release; only release prep and fixes, then merge to `main` and back into `develop`.
+- **`hotfix/*`** — branch from `main` for urgent production fixes, then merge to `main` and `develop`.
+
+If your change is small and the team agrees on an exception, ask before opening a feature PR against `main`.
+
+## Commit messages (Conventional Commits)
+
+Use **[Conventional Commits](https://www.conventionalcommits.org/)** so history and changelogs stay readable.
+
+Format:
+
+```
+<type>(<scope>): <subject>
+
+- optional bullet (keep the body short; two bullets max)
+```
+
+- **Types** we use: `feat`, `fix`, `refactor`, `test`, `style`, `docs`, `chore`, `perf`, `ci`, `build`, `revert`.
+- **Subject**: imperative mood, lowercase, no trailing period, about **72 characters** max.
+- **Scope**: optional; name the area (for example `gateway`, `ledger-service`, `ci`).
+- **Breaking changes**: add `!` after the type or scope, for example `feat(api)!: remove legacy transfer endpoint`.
+
+Squash merges should preserve a conventional **subject line** on the main integration branch.
+
 ## Pull requests
 
+- Branch from **`develop`** using the Gitflow rules above, unless you are on a release or hotfix line.
 - Keep the change focused on one concern when possible.
 - Describe **what** changed and **why** in the PR body (plain language is enough).
 - Ensure CI is green before requesting review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to rails-core
+
+Thanks for helping improve the project. This document is intentionally short: get oriented, run checks locally, open a PR.
+
+## Run locally
+
+1. Clone the repository and `cd rails-core`.
+2. `cp .env.example .env` and set the three `*_DATABASE_URL` values to real Postgres databases (one schema per service is fine if you know what you are doing; the default template assumes separate DB names).
+3. `make dev` starts nginx on [http://localhost:8080](http://localhost:8080) and all three application containers.
+
+See [README.md](README.md) for URLs, a copy-paste **curl** example, and what belongs in scope for this repo.
+
+## How services are structured
+
+- **users-service** — Rust (Axum). HTTP under `/users/` on the gateway; gRPC for internal callers.
+- **accounts-service** — Rust (Axum). HTTP under `/accounts/`; gRPC to **users** (API key validation) and **ledger** (postings).
+- **ledger-service** — Rails. HTTP under `/ledger/`; gRPC server for ledger operations.
+
+Shared API contracts live under `proto/`. The gateway strips the path prefix (`/users/`, `/accounts/`, `/ledger/`) before forwarding.
+
+## Add or change an HTTP endpoint
+
+1. Implement the handler in the correct service (`services/<name>-service/`).
+2. Register the route in that service’s router module (search for `Router::new` or `route(` in `src/` or Rails `config/routes.rb` for ledger).
+3. If the route should be public via the monorepo gateway, confirm `gateway/nginx.conf` already proxies the right prefix (it usually does).
+4. Add or update tests next to the service (`cargo test`, `rails test`, or request specs as established in that tree).
+
+## Run tests
+
+From each service directory, use the same commands CI uses:
+
+- **users-service** and **accounts-service**: `cargo clippy`, `cargo test` (install `protobuf-compiler` on Linux if `tonic` build fails).
+- **ledger-service**: `bundle install` then `bin/rails test` (or `bundle exec rails test`) with `RAILS_ENV=test` and a `DATABASE_URL` pointing at a test database.
+
+From the repository root, `make verify` checks that vendored service folders exist.
+
+## Pull requests
+
+- Keep the change focused on one concern when possible.
+- Describe **what** changed and **why** in the PR body (plain language is enough).
+- Ensure CI is green before requesting review.
+
+No RFC process or architecture committee: if something is unclear, open a draft PR or issue and we iterate in the thread.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,15 +36,13 @@ From the repository root, `make verify` checks that vendored service folders exi
 
 ## Branching (Gitflow)
 
-We follow **Gitflow**-style branching:
+Long-lived branches are **`main`** (production-ready) and **`develop`** (integration). We follow **Gitflow**-style branching for everything else:
 
-- **`main`** — production-ready history; only merges from `release/*` or `hotfix/*`.
-- **`develop`** — day-to-day integration; default base for new work.
-- **`feature/*`** — branch from `develop` for new work (for example `feature/rai-6-open-source-readiness`). Open a PR back into `develop`.
-- **`release/*`** — branch from `develop` when cutting a release; only release prep and fixes, then merge to `main` and back into `develop`.
-- **`hotfix/*`** — branch from `main` for urgent production fixes, then merge to `main` and `develop`.
+- **`feature/*`** — branch from `develop` (for example `feature/rai-6-open-source-readiness`).
+- **`release/*`** — cut from `develop` for a release; merges to `main` and back into `develop` (usually maintainer-driven).
+- **`hotfix/*`** — branched from `main` for urgent production fixes; merges to `main` and `develop` (usually maintainer-driven).
 
-If your change is small and the team agrees on an exception, ask before opening a feature PR against `main`.
+**All pull requests must target `develop`.** Do not open PRs against `main`; production updates flow from `develop` via release/hotfix merges handled outside normal contributor PRs.
 
 ## Commit messages (Conventional Commits)
 
@@ -63,11 +61,12 @@ Format:
 - **Scope**: optional; name the area (for example `gateway`, `ledger-service`, `ci`).
 - **Breaking changes**: add `!` after the type or scope, for example `feat(api)!: remove legacy transfer endpoint`.
 
-Squash merges should preserve a conventional **subject line** on the main integration branch.
+Squash merges should preserve a conventional **subject line** on `develop`.
 
 ## Pull requests
 
-- Branch from **`develop`** using the Gitflow rules above, unless you are on a release or hotfix line.
+- **Base branch:** every PR must target **`develop`**.
+- Branch your work from **`develop`** (see Gitflow above).
 - Keep the change focused on one concern when possible.
 - Describe **what** changed and **why** in the PR body (plain language is enough).
 - Ensure CI is green before requesting review.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REPO_ROOT := $(abspath $(RAILS_CORE))
 
 help:
 	@echo "rails-core (repo root: $(REPO_ROOT))"
-	@echo "  make dev        — Docker Compose: nginx :8080 + all services"
+	@echo "  make dev        — bootstrap + Docker Compose: nginx :8080 + all services"
 	@echo "  make bootstrap  — verify vendored service directories exist"
 	@echo "  make verify     — assert service directories exist"
 	@echo "  make health     — HTTP checks via gateway :8080 (compose must be up)"
@@ -28,6 +28,15 @@ seed:
 reset:
 	@bash "$(RAILS_CORE)scripts/reset.sh"
 
-dev:
+dev: bootstrap
 	@test -f "$(RAILS_CORE).env" || (echo "Missing $(RAILS_CORE).env — run: cp .env.example .env" && exit 1)
+	@echo ""
+	@echo "Starting Docker Compose (first run may compile Rust/Ruby for several minutes)."
+	@echo "When containers are healthy, use the gateway on port 8080:"
+	@echo "  Gateway + APIs: http://localhost:8080/"
+	@echo "  Static docs:    http://localhost:8080/docs/"
+	@echo "  Users API:      http://localhost:8080/users/..."
+	@echo "  Accounts API:   http://localhost:8080/accounts/..."
+	@echo "  Ledger API:     http://localhost:8080/ledger/..."
+	@echo ""
 	cd "$(RAILS_CORE)" && docker compose --env-file .env up --build

--- a/README.md
+++ b/README.md
@@ -1,32 +1,126 @@
 # rails-core
 
+## What this project is / is not
+
+**This project is**
+
+- Financial infrastructure backends (users, accounts, double-entry ledger)
+- A multi-service system coordinated through an **nginx** gateway
+- A developer-first HTTP + gRPC API platform
+- **Local-dev first**: Docker Compose on your machine, external Postgres (for example Neon)
+
+**This project is not**
+
+- A single monolith
+- A hosted production SaaS product as shipped from this repository
+- A Kubernetes-first or cluster-required stack
+- Banking licensing, compliance-as-a-service, or a turnkey regulated product
+
+---
+
 Lean **financial infrastructure**: three services (Rust + Rails), an **nginx** gateway, **proto** contracts, **Docker Compose**, and **`.env.example`**.
 
-## Quick start
+## Quick start (one command after env)
 
 ```bash
-cp .env.example .env   # set USERS_/ACCOUNTS_/LEDGER_ database URLs
-make bootstrap         # verify service directories exist
-make dev               # http://localhost:8080 — gateway + all services
+git clone https://github.com/railsinfra/rails-core.git
+cd rails-core
+cp .env.example .env
+# Edit .env: set USERS_DATABASE_URL, ACCOUNTS_DATABASE_URL, LEDGER_DATABASE_URL (three databases).
+make dev
 ```
+
+`make dev` runs a fast layout check (`make bootstrap`), then starts **Docker Compose**. The first run can take several minutes while Rust and Ruby dependencies compile inside the containers.
+
+### When things are up
+
+| What | URL / path |
+|------|------------|
+| Gateway (redirects to docs) | [http://localhost:8080/](http://localhost:8080/) |
+| Static docs (served by gateway) | [http://localhost:8080/docs/](http://localhost:8080/docs/) |
+| Users HTTP API (via gateway) | `http://localhost:8080/users/...` |
+| Accounts HTTP API (via gateway) | `http://localhost:8080/accounts/...` |
+| Ledger HTTP API (via gateway) | `http://localhost:8080/ledger/...` |
+
+Services speak to each other on the Docker network; you normally **do not** need separate host ports for each service. Everything goes through **:8080**.
 
 ### Stop the stack
 
 ```bash
-make reset             # docker compose down --remove-orphans (reads .env if present)
+make reset
 ```
 
-Use this before starting again if Compose reports a **container name conflict**, or if you left containers running in the background.
-
-### Other Make targets
+### Optional checks
 
 | Command | Purpose |
 |--------|---------|
-| `make help` | List targets and short descriptions |
-| `make bootstrap` | Same checks as quick start: vendored service dirs exist |
+| `make help` | List targets |
 | `make verify` | Assert service directories from `config/services.json` exist |
-| `make health` | HTTP checks via the gateway on `:8080` (expects `make dev` to be up) |
-| `make seed` | Placeholder; see `scripts/seed.sh` |
+| `make health` | HTTP smoke checks via the gateway (expects the stack to be running) |
+
+## Three services (short)
+
+| Service | Role |
+|--------|------|
+| **users-service** (Rust) | Businesses, environments, auth, API keys |
+| **accounts-service** (Rust) | Accounts, balances, transfers; talks to users + ledger over gRPC |
+| **ledger-service** (Rails) | Double-entry ledger over gRPC (and HTTP under `/ledger/`) |
+
+## Example API flow (curl)
+
+All calls below use the gateway. Replace emails if you already registered the same address.
+
+```bash
+export BASE=http://localhost:8080
+
+# 1) Register a business (creates admin user + tokens)
+REG=$(curl -sS -X POST "$BASE/users/api/v1/business/register" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Demo Co","website":"https://example.com","admin_first_name":"Ada","admin_last_name":"Lovelace","admin_email":"ada+demo@example.com","admin_password":"SecurePass123!"}')
+echo "$REG" | jq .
+
+export ACCESS=$(echo "$REG" | jq -r .access_token)
+export ENV_ID=$(echo "$REG" | jq -r .selected_environment_id)
+
+# 2) Create a server API key (plaintext shown once)
+KEY_JSON=$(curl -sS -X POST "$BASE/users/api/v1/api-keys" \
+  -H "Authorization: Bearer $ACCESS" \
+  -H "X-Environment-Id: $ENV_ID" \
+  -H "Content-Type: application/json" \
+  -d '{}')
+echo "$KEY_JSON" | jq .
+export API_KEY=$(echo "$KEY_JSON" | jq -r .key)
+
+# 3) Create two checking accounts (different holder emails, same org via API key)
+A=$(curl -sS -X POST "$BASE/accounts/api/v1/accounts" \
+  -H "X-API-Key: $API_KEY" \
+  -H "X-Environment: sandbox" \
+  -H "Content-Type: application/json" \
+  -d '{"account_type":"checking","email":"holder-a@example.com","first_name":"A","last_name":"One"}')
+B=$(curl -sS -X POST "$BASE/accounts/api/v1/accounts" \
+  -H "X-API-Key: $API_KEY" \
+  -H "X-Environment: sandbox" \
+  -H "Content-Type: application/json" \
+  -d '{"account_type":"checking","email":"holder-b@example.com","first_name":"B","last_name":"Two"}')
+export FROM_ID=$(echo "$A" | jq -r .id)
+export TO_ID=$(echo "$B" | jq -r .id)
+
+# 4) Deposit funds on the first account (amounts are in minor units, e.g. cents)
+curl -sS -X POST "$BASE/accounts/api/v1/accounts/$FROM_ID/deposit" \
+  -H "X-Environment: sandbox" \
+  -H "Idempotency-Key: readme-deposit-1" \
+  -H "Content-Type: application/json" \
+  -d '{"amount":100000}' | jq .
+
+# 5) Transfer between accounts
+curl -sS -X POST "$BASE/accounts/api/v1/accounts/$FROM_ID/transfer" \
+  -H "X-Environment: sandbox" \
+  -H "Idempotency-Key: readme-transfer-1" \
+  -H "Content-Type: application/json" \
+  -d "{\"to_account_id\":\"$TO_ID\",\"amount\":5000}" | jq .
+```
+
+If `INTERNAL_SERVICE_TOKEN_ALLOWLIST` is set in the users service, sensitive routes also require `X-Internal-Service-Token` (see [services/users-service/README.md](services/users-service/README.md)). The sample `docker-compose.yml` does not set it, so local open registration works out of the box.
 
 ## Layout
 
@@ -71,15 +165,17 @@ rails-core/
 ├── docker-compose.yml
 ├── Makefile
 ├── README.md
+├── CONTRIBUTING.md
 ├── .gitignore
 └── .env.example
 ```
 
-## Docs
+## Docs and contributing
 
 - [docs/architecture.md](docs/architecture.md) — diagram, boundaries, request flow  
 - [docs/quickstart.md](docs/quickstart.md) — clone → env → `make dev`  
 - [docs/RAILWAY_DEPLOYMENT.md](docs/RAILWAY_DEPLOYMENT.md) — optional Railway helper for Rust services  
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to change code and open a PR  
 
 ## Service manifest
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Rails-core: single entry via nginx on host port 8080.
 # Requires: cp .env.example .env and external Postgres URLs (Neon, etc.).
-# Requires: git submodule update --init (see make bootstrap).
+# Services are vendored under services/ (see make bootstrap).
 
 services:
   gateway:
@@ -23,11 +23,14 @@ services:
       - ./services/users-service:/app
     environment:
       DATABASE_URL: ${USERS_DATABASE_URL}
-      HTTP_PORT: "8080"
+      SERVER_ADDR: "0.0.0.0:8080"
+      GRPC_PORT: "50051"
+      ACCOUNTS_GRPC_URL: http://accounts-service:9090
       RUST_LOG: ${RUST_LOG:-info}
     command: bash -c "cargo run --release"
     expose:
       - "8080"
+      - "50051"
 
   accounts-service:
     image: rust:1.85-bookworm
@@ -37,10 +40,14 @@ services:
     environment:
       DATABASE_URL: ${ACCOUNTS_DATABASE_URL}
       PORT: "8080"
+      GRPC_PORT: "9090"
+      USERS_GRPC_URL: http://users-service:50051
+      LEDGER_GRPC_URL: http://ledger-service:50053
       RUST_LOG: ${RUST_LOG:-info}
     command: bash -c "cargo run --release"
     expose:
       - "8080"
+      - "9090"
 
   ledger-service:
     image: ruby:3.3.0-bookworm
@@ -51,6 +58,8 @@ services:
       DATABASE_URL: ${LEDGER_DATABASE_URL}
       RAILS_ENV: development
       PORT: "3000"
+      GRPC_PORT: "50053"
     command: bash -c "bundle install && bundle exec rails server -b 0.0.0.0 -p 3000"
     expose:
       - "3000"
+      - "50053"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,10 +5,9 @@
 ```bash
 git clone git@github.com:railsinfra/rails-core.git
 cd rails-core
-make bootstrap
 ```
 
-(`bootstrap` checks that every path in `config/services.json` exists — services are **vendored** in this repo, not submodules.)
+`make dev` runs the same layout check as `make bootstrap` (paths in `config/services.json` — services are **vendored** in this repo, not git submodules).
 
 ## 2. Environment
 


### PR DESCRIPTION
Closes [RAI-6](https://linear.app/railsinfra/issue/RAI-6/story-open-source-readiness-rails-core).

## Summary

- README: scope (is/is not), quick start, gateway URLs, three-service overview, end-to-end curl + jq example (register → API key → accounts → deposit → transfer).
- `make dev`: runs bootstrap, prints service URLs, starts Compose.
- `docker-compose.yml`: service-to-service gRPC URLs, Rust 1.85 / Ruby 3.3.0 alignment, vendored-services comment.
- `.env.example`: safe DB placeholders and optional dev notes.
- Root GitHub Actions CI on pull requests: compose config, Rust clippy + tests per service, ledger tests with Postgres, Dockerfile builds.
- `CONTRIBUTING.md`: local run, structure, endpoints, tests, Gitflow (PRs → `develop`), Conventional Commits.
- `docs/quickstart.md`: aligned with `make dev` running bootstrap.

## Validation against RAI-6

| Requirement | Status |
|-------------|--------|
| README single source + quick start + URLs + scope + curl | Done |
| Primary entry `make dev` (bootstrap, compose, URL hints) | Done |
| CONTRIBUTING.md (<150 lines), lightweight PR flow | Done |
| `.env.example` three DB URLs, no secrets | Done |
| GHA: PR-only, lint (clippy), tests, docker build | Done |
| Story ports 8081/8082/3000 | Documented as gateway :8080 (actual architecture) |