### PR TITLE
feat(scripts): RAI-8 integration smoke and make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Rails-core standalone repository Makefile.
-.PHONY: help dev bootstrap verify health reset seed
+.PHONY: help dev bootstrap verify health test reset seed
 
 RAILS_CORE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(abspath $(RAILS_CORE))
@@ -10,6 +10,7 @@ help:
 	@echo "  make bootstrap  — verify vendored service directories exist"
 	@echo "  make verify     — assert service directories exist"
 	@echo "  make health     — HTTP checks via gateway :8080 (compose must be up)"
+	@echo "  make test       — health + cross-service contract tests (stack must be up)"
 	@echo "  make reset      — docker compose down"
 	@echo "  make seed       — placeholder (see script)"
 
@@ -21,6 +22,9 @@ verify:
 
 health:
 	@bash "$(RAILS_CORE)scripts/health-check.sh"
+
+test: verify
+	@bash "$(RAILS_CORE)scripts/system-test.sh"
 
 seed:
 	@bash "$(RAILS_CORE)scripts/seed.sh"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ make reset
 | `make help` | List targets |
 | `make verify` | Assert service directories from `config/services.json` exist |
 | `make health` | HTTP smoke checks via the gateway (expects the stack to be running) |
+| `make test` | Gateway health JSON (users/accounts: `healthy`, ledger: `ok`) plus contract flow users → accounts → ledger |
 
 ## Three services (short)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,7 +38,18 @@ Wait for first-time `cargo`/`bundle` downloads. Then open:
 
 Read [architecture.md](architecture.md) for the one-page diagram and boundaries.
 
-## 5. Stop / reset containers
+## 5. Health and contract tests (optional)
+
+With the stack still running:
+
+```bash
+make health   # gateway: /users/health, /accounts/health, /ledger/health + /docs/
+make test     # health JSON checks + full users → accounts → ledger HTTP flow
+```
+
+`make test` expects the gateway at `http://127.0.0.1:8080` unless you set `GATEWAY_URL`.
+
+## 6. Stop / reset containers
 
 ```bash
 make reset
@@ -48,6 +59,6 @@ make reset
 
 This stops Docker Compose; it does **not** drop external databases.
 
-## 6. Optional consumers
+## 7. Optional consumers
 
 Admin UI and other gateways can call this stack through **http://localhost:8080** during local development; they live in separate repositories (for example under the `railsinfra` org).

--- a/scripts/lib/health_check.py
+++ b/scripts/lib/health_check.py
@@ -1,41 +1,65 @@
 """HTTP checks against the nginx gateway (default http://127.0.0.1:8080)."""
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 
 
-def main() -> int:
-    base = os.environ.get("GATEWAY_URL", "http://127.0.0.1:8080").rstrip("/")
-    checks = [
-        (f"{base}/users/health", "users health"),
-        (f"{base}/accounts/health", "accounts health"),
-        (f"{base}/docs/", "docs static"),
-    ]
-    failures = 0
-    for url, label in checks:
-        r = subprocess.run(
-            ["curl", "-fsS", "--max-time", "3", url],
-            capture_output=True,
-            text=True,
-        )
-        if r.returncode == 0:
-            print(f"OK  {label} {url}")
-        else:
-            print(f"FAIL {label} {url}", file=sys.stderr)
-            failures += 1
-    # Ledger may not expose GET /health; best-effort root through gateway.
-    ledger = f"{base}/ledger/"
+def _curl_body(url: str) -> tuple[int, str]:
     r = subprocess.run(
-        ["curl", "-fsS", "--max-time", "3", "-o", "/dev/null", "-w", "%{http_code}", ledger],
+        ["curl", "-fsS", "--max-time", "10", url],
         capture_output=True,
         text=True,
     )
-    if r.returncode == 0 and r.stdout.strip() in ("200", "302", "301", "404"):
-        print(f"OK  ledger gateway {ledger} (HTTP {r.stdout.strip()})")
+    return r.returncode, r.stdout
+
+
+def _check_health_json(url: str, label: str) -> bool:
+    code, body = _curl_body(url)
+    if code != 0:
+        print(f"FAIL {label} {url} (curl exit {code})", file=sys.stderr)
+        return False
+    try:
+        obj = json.loads(body)
+    except json.JSONDecodeError:
+        print(f"FAIL {label} {url} (invalid JSON)", file=sys.stderr)
+        return False
+    # Rust services use "healthy"; ledger uses "ok" — both mean up.
+    if obj.get("status") not in ("ok", "healthy"):
+        print(
+            f"FAIL {label} {url} (expected status ok|healthy, got {obj.get('status')!r})",
+            file=sys.stderr,
+        )
+        return False
+    print(f"OK  {label} {url}")
+    return True
+
+
+def main() -> int:
+    base = os.environ.get("GATEWAY_URL", "http://127.0.0.1:8080").rstrip("/")
+    failures = 0
+    for path, label in (
+        (f"{base}/users/health", "users health"),
+        (f"{base}/accounts/health", "accounts health"),
+        (f"{base}/ledger/health", "ledger health"),
+    ):
+        if not _check_health_json(path, label):
+            failures += 1
+
+    docs = f"{base}/docs/"
+    r = subprocess.run(
+        ["curl", "-fsS", "--max-time", "10", docs],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode == 0:
+        print(f"OK  docs static {docs}")
     else:
-        print(f"WARN ledger gateway {ledger} (non-fatal)", file=sys.stderr)
+        print(f"FAIL docs static {docs}", file=sys.stderr)
+        failures += 1
+
     return 1 if failures else 0
 
 

--- a/scripts/system-test.sh
+++ b/scripts/system-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Full-stack smoke: gateway health JSON, then cross-service contract flow.
+# Expects Docker Compose (or equivalent) already listening on GATEWAY_URL.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:8080}"
+
+echo "== Health (gateway) =="
+python3 "$ROOT/scripts/lib/health_check.py"
+
+echo ""
+echo "== Contract: register → API key → account → deposit → ledger entries =="
+python3 "$ROOT/tests/contracts/smoke_flow.py"
+
+echo ""
+echo "OK  system test passed"

--- a/tests/contracts/smoke_flow.py
+++ b/tests/contracts/smoke_flow.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Cross-service contract: users → accounts (incl. ledger via deposit) → ledger HTTP read.
+
+Requires a running gateway (default http://127.0.0.1:8080) and reachable databases.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+
+def gateway_base() -> str:
+    return os.environ.get("GATEWAY_URL", "http://127.0.0.1:8080").rstrip("/")
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    json_body: dict | None = None,
+    timeout: int = 120,
+) -> tuple[int, dict]:
+    h = dict(headers or {})
+    data = None
+    if json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        h.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, data=data, method=method, headers=h)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode()
+            body = json.loads(text) if text.strip() else {}
+            return resp.getcode() or 200, body
+    except urllib.error.HTTPError as e:
+        text = e.read().decode()
+        try:
+            body = json.loads(text) if text.strip() else {}
+        except json.JSONDecodeError:
+            body = {"_raw": text}
+        raise RuntimeError(f"HTTP {e.code} {method} {url}: {body}") from e
+
+
+def main() -> int:
+    base = gateway_base()
+    suffix = uuid.uuid4().hex[:12]
+    admin_email = f"contract-{suffix}@example.com"
+    holder_email = f"holder-{suffix}@example.com"
+
+    print(f"Using gateway {base}")
+
+    # 1) Register business (creates org + admin user + JWT)
+    reg_url = f"{base}/users/api/v1/business/register"
+    _, reg = request_json(
+        "POST",
+        reg_url,
+        json_body={
+            "name": f"Contract Co {suffix}",
+            "website": "https://example.com",
+            "admin_first_name": "Contract",
+            "admin_last_name": "Test",
+            "admin_email": admin_email,
+            "admin_password": "SecurePass123!",
+        },
+    )
+    access = reg["access_token"]
+    env_id = str(reg["selected_environment_id"])
+    business_id = str(reg["business_id"])
+    admin_user_id = str(reg["admin_user_id"])
+    if not access or not business_id or not admin_user_id:
+        print("FAIL register: missing token or ids", file=sys.stderr)
+        return 1
+    print(f"OK  users register business_id={business_id} admin_user_id={admin_user_id}")
+
+    # 2) Server API key
+    key_url = f"{base}/users/api/v1/api-keys"
+    _, key_body = request_json(
+        "POST",
+        key_url,
+        headers={
+            "Authorization": f"Bearer {access}",
+            "X-Environment-Id": env_id,
+        },
+        json_body={"environment_id": env_id},
+    )
+    api_key = key_body.get("key")
+    if not api_key:
+        print("FAIL api key response missing plaintext key", file=sys.stderr)
+        return 1
+    print("OK  users api key created")
+
+    # 3) Account (holder path — ties to org via API key)
+    acc_url = f"{base}/accounts/api/v1/accounts"
+    _, account = request_json(
+        "POST",
+        acc_url,
+        headers={
+            "X-API-Key": api_key,
+            "X-Environment": "sandbox",
+        },
+        json_body={
+            "account_type": "checking",
+            "email": holder_email,
+            "first_name": "H",
+            "last_name": "older",
+        },
+    )
+    account_id = str(account.get("id") or "")
+    org_id = str(account.get("organization_id") or "")
+    holder_id = account.get("holder_id")
+    user_id = account.get("user_id")
+    if not account_id or org_id != business_id:
+        print(
+            f"FAIL account: id={account_id!r} organization_id={org_id!r} expected business {business_id}",
+            file=sys.stderr,
+        )
+        return 1
+    if holder_id is None and user_id is None:
+        print("FAIL account: expected holder_id or user_id", file=sys.stderr)
+        return 1
+    print(f"OK  accounts create account_id={account_id} holder_id={holder_id} user_id={user_id}")
+
+    # 4) Deposit (posts through accounts → ledger gRPC)
+    dep_url = f"{base}/accounts/api/v1/accounts/{account_id}/deposit"
+    _, dep = request_json(
+        "POST",
+        dep_url,
+        headers={
+            "X-Environment": "sandbox",
+            "Idempotency-Key": f"contract-deposit-{suffix}",
+        },
+        json_body={"amount": 10_000},
+    )
+    if "transaction" not in dep or "account" not in dep:
+        print(f"FAIL deposit response shape: {list(dep.keys())}", file=sys.stderr)
+        return 1
+    print("OK  accounts deposit (ledger mutation)")
+
+    # 5) Ledger HTTP: list entries for this external account
+    entries_url = f"{base}/ledger/api/v1/ledger/entries?account_id={account_id}&per_page=20"
+    _, entries = request_json(
+        "GET",
+        entries_url,
+        headers={
+            "Authorization": f"Bearer {access}",
+            "X-Environment": "sandbox",
+        },
+    )
+    rows = entries.get("data")
+    if not isinstance(rows, list) or not rows:
+        print(f"FAIL ledger entries empty or invalid: {entries!r}", file=sys.stderr)
+        return 1
+    ext_ids = {str(r.get("external_account_id")) for r in rows}
+    if account_id not in ext_ids:
+        print(f"FAIL ledger entries missing account_id {account_id} in {ext_ids}", file=sys.stderr)
+        return 1
+    print(f"OK  ledger entries (n={len(rows)}) reference account {account_id}")
+
+    # Gateway path sanity: all three prefixes served something versioned above
+    print("OK  contract flow complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes RAI-8.

## Summary
Adds `make test` (layout verify, strict gateway health JSON for users/accounts/ledger, then a real HTTP contract flow). Documents usage in README and quickstart.

## Test plan
- [ ] `make dev` with valid `.env` databases, then `make test`