### PR TITLE
feat(devx): RAI-10 docker/make health wait and neon console links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,20 @@ ACCOUNTS_DATABASE_URL=postgresql://USER:PASSWORD@YOUR_POSTGRES_HOST:5432/account
 LEDGER_DATABASE_URL=postgresql://USER:PASSWORD@YOUR_POSTGRES_HOST:5432/ledger_db
 
 NEON_API_KEY=your-neon-api-key
-# Optional — shorten Neon console HTTPS links in bootstrap output (Bitly generic access token):
+# Optional — shorten Neon console links in bootstrap (Bitly preferred; otherwise is.gd, no key).
+# Set NEON_CONSOLE_NO_PUBLIC_SHORTENER=yes to disable is.gd and only use Bitly (or long URLs).
 # BITLY_ACCESS_TOKEN=
+# BITLY_GROUP_GUID=   # optional; default group from GET /v4/groups if omitted
+# NEON_CONSOLE_NO_PUBLIC_SHORTENER=yes
 # NEON_REGION_ID=aws-us-east-1
 # RAILS_CORE_NEON_PROJECT_NAME=rails-core-dev
 
 # Optional — logging for Rust services in Docker Compose
 RUST_LOG=info
+
+# Optional — `make dev` waits for gateway health (default 900s). First Rust compile can exceed that.
+# DEV_WAIT_TIMEOUT_SEC=1200
+# DEV_WAIT_INTERVAL_SEC=5
 
 # Optional — only when running Rust services on the host (not needed for `make dev`):
 # ACCOUNTS_GRPC_URL=http://127.0.0.1:9090

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 # Rails-core standalone repository Makefile.
-.PHONY: help dev bootstrap verify health test reset reset-env reset-neon seed
+.PHONY: help dev bootstrap verify health test reset stop logs reset-env reset-neon seed
 
 RAILS_CORE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(abspath $(RAILS_CORE))
 
 help:
 	@echo "rails-core (repo root: $(REPO_ROOT))"
-	@echo "  make dev        — bootstrap + Docker Compose: nginx :8080 + all services"
+	@echo "  make dev        — bootstrap + compose up -d --build + wait for /health (then prints URLs)"
 	@echo "  make bootstrap  — layout check + Neon/.env (see .env.example for NEON_API_KEY)"
 	@echo "  make verify     — assert service directories exist"
 	@echo "  make health     — HTTP checks via gateway :8080 (compose must be up)"
 	@echo "  make test       — health + cross-service contract tests (stack must be up)"
+	@echo "  make logs       — docker compose logs -f (stack must be up; requires .env)"
 	@echo "  make reset      — docker compose down"
+	@echo "  make stop       — same as make reset"
 	@echo "  make reset-env  — clear DB URLs in .env (local only; keeps other keys)"
 	@echo "  make reset-neon — delete Neon project from .env (requires CONFIRM_PURGE_NEON=yes)"
 	@echo "  make seed       — placeholder (see script)"
@@ -34,6 +36,12 @@ seed:
 reset:
 	@bash "$(RAILS_CORE)scripts/reset.sh"
 
+stop: reset
+
+logs:
+	@test -f "$(RAILS_CORE).env" || (echo "Missing $(RAILS_CORE).env — run make bootstrap first." && exit 1)
+	@cd "$(REPO_ROOT)" && docker compose --env-file .env logs -f
+
 reset-env:
 	@bash "$(RAILS_CORE)scripts/reset.sh" --clear-env
 
@@ -43,8 +51,7 @@ reset-neon:
 dev: bootstrap
 	@test -f "$(RAILS_CORE).env" || (echo "Missing $(RAILS_CORE).env after bootstrap — see scripts/bootstrap.sh output." && exit 1)
 	@echo ""
-	@echo "Starting Docker Compose (first run may compile Rust/Ruby for several minutes)."
-	@echo "When containers are healthy, use the gateway on port 8080:"
-	@python3 "$(RAILS_CORE)scripts/lib/print_gateway_hints.py"
-	@echo ""
-	cd "$(RAILS_CORE)" && docker compose --env-file .env up --build
+	@echo "Starting Docker Compose in the background (first run may compile Rust/Ruby for many minutes)."
+	@echo "Containers will restart on failure; gateway starts after app healthchecks pass."
+	@cd "$(REPO_ROOT)" && docker compose --env-file .env up -d --build
+	@RAILS_CORE_ROOT="$(REPO_ROOT)" python3 "$(RAILS_CORE)scripts/lib/wait_for_stack.py"

--- a/README.md
+++ b/README.md
@@ -34,19 +34,22 @@ cp .env.example .env
 
 Set `NEON_API_KEY` in `.env` ([Neon API keys](https://neon.tech/docs/manage/api-keys)).
 
+After provisioning, bootstrap prints a credentials table with **short Neon console links**: it tries **Bitly** when `BITLY_ACCESS_TOKEN` is set (see `.env.example`), otherwise **`is.gd`** via the standard library (no extra Python package). Set `NEON_CONSOLE_NO_PUBLIC_SHORTENER=yes` if you must not send console URLs to a third-party shortener.
+
 ### 3. Run
 
 ```bash
 make dev
 ```
 
-`make dev` runs a fast layout check (`make bootstrap`), then starts **Docker Compose**. The first run can take several minutes while Rust and Ruby dependencies compile inside the containers.
+`make dev` runs `make bootstrap`, then **`docker compose up -d --build`**, then waits until **gateway and service health checks** pass (see `scripts/lib/health_check.py`). The first run can take a long time while Rust and Ruby compile inside the containers; override the wait with `DEV_WAIT_TIMEOUT_SEC` if needed. Follow container output with **`make logs`**.
 
 ### When things are up
 
 | What | URL / path |
 |------|------------|
 | Gateway (redirects to docs) | [http://localhost:8080/](http://localhost:8080/) |
+| Gateway liveness JSON | [http://localhost:8080/health](http://localhost:8080/health) |
 | Static docs (served by gateway) | [http://localhost:8080/docs/](http://localhost:8080/docs/) |
 | Users HTTP API (via gateway) | `http://localhost:8080/users/...` |
 | Accounts HTTP API (via gateway) | `http://localhost:8080/accounts/...` |
@@ -60,6 +63,8 @@ Services speak to each other on the Docker network; you normally **do not** need
 | Command | What it does |
 |--------|----------------|
 | `make reset` | `docker compose down` (stops local containers; external DBs unchanged). |
+| `make stop` | Same as `make reset`. |
+| `make logs` | `docker compose logs -f` (requires `.env`; stack must already be running). |
 | `make reset-env`  | Rewrites `USERS_DATABASE_URL`, `ACCOUNTS_DATABASE_URL`, and `LEDGER_DATABASE_URL` in `.env` back to the placeholders from `.env.example`. Does **not** delete data in Neon. |
 | `make reset-neon` | Deletes the Neon **project** whose id is in `RAILS_CORE_NEON_PROJECT_ID` in `.env`, clears those database URL lines to placeholders, and strips Neon metadata keys. **Requires** `CONFIRM_PURGE_NEON=yes` in the environment, for example: `CONFIRM_PURGE_NEON=yes make reset-neon`. |
 
@@ -70,8 +75,8 @@ Services speak to each other on the Docker network; you normally **do not** need
 |--------|---------|
 | `make help` | List targets |
 | `make verify` | Assert service directories from `config/services.json` exist |
-| `make health` | HTTP smoke checks via the gateway (expects the stack to be running) |
-| `make test` | Gateway health JSON (users/accounts: `healthy`, ledger: `ok`) plus contract flow users → accounts → ledger |
+| `make health` | HTTP smoke checks via the gateway: `/health`, `/users/health`, `/accounts/health`, `/ledger/health`, and `/docs/` |
+| `make test` | Gateway health JSON (`/health` + per-service paths: users/accounts `healthy`, ledger `ok`) plus contract flow users → accounts → ledger |
 
 ## Three services (short)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,20 +5,31 @@
 services:
   gateway:
     image: nginx:1.25-alpine
+    restart: unless-stopped
     ports:
       - "8080:80"
     volumes:
       - ./gateway/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docs:/usr/share/nginx/html/docs:ro
     depends_on:
-      - users-service
-      - accounts-service
-      - ledger-service
+      users-service:
+        condition: service_healthy
+      accounts-service:
+        condition: service_healthy
+      ledger-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   users-service:
     # home crate (transitive) requires rustc 1.88+; keep in sync with accounts-service.
     # prost-build needs `protoc` (protobuf-compiler) at compile time.
     image: rust:1.88-bookworm
+    restart: unless-stopped
     working_dir: /app
     volumes:
       - ./services/users-service:/app
@@ -32,9 +43,16 @@ services:
     expose:
       - "8080"
       - "50051"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS --max-time 5 http://127.0.0.1:8080/health >/dev/null"]
+      interval: 15s
+      timeout: 8s
+      retries: 5
+      start_period: 1200s
 
   accounts-service:
     image: rust:1.88-bookworm
+    restart: unless-stopped
     working_dir: /app
     volumes:
       - ./services/accounts-service:/app
@@ -49,9 +67,16 @@ services:
     expose:
       - "8080"
       - "9090"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS --max-time 5 http://127.0.0.1:8080/health >/dev/null"]
+      interval: 15s
+      timeout: 8s
+      retries: 5
+      start_period: 1200s
 
   ledger-service:
     image: ruby:3.3.0-bookworm
+    restart: unless-stopped
     working_dir: /app
     volumes:
       - ./services/ledger-service:/app
@@ -65,3 +90,9 @@ services:
     expose:
       - "3000"
       - "50053"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS --max-time 5 http://127.0.0.1:3000/health >/dev/null"]
+      interval: 15s
+      timeout: 8s
+      retries: 5
+      start_period: 900s

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,6 @@ Add RPCs here **before** implementing cross-service calls. Version bump = v2 pac
 
 - **Single env file:** `.env` at the repository root (copy from `.env.example`).
 - **No local Postgres in compose:** services read `*_DATABASE_URL` pointing at hosted Postgres.
-- **One command:** `make dev` runs Compose: builds/runs Rust & Rails in dev images with bind mounts, starts nginx on **8080**.
+- **One command:** `make dev` runs Compose (`up -d --build`), waits for `/health` through the gateway, then prints URLs; nginx stays on **8080**. Use `make logs` for container output.
 
 See [quickstart.md](quickstart.md) for exact commands.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ git clone git@github.com:railsinfra/rails-core.git
 cd rails-core
 ```
 
-`make dev` runs the same layout check as `make bootstrap` (paths in `config/services.json` — services are **vendored** in this repo, not git submodules).
+`make dev` runs the same layout check as `make bootstrap` (paths in `config/services.json` — services are **vendored** in this repo, not git submodules), brings Compose up in the background (`docker compose up -d --build`), then blocks until health checks pass. Use `make logs` to stream container logs.
 
 ## 2. Environment
 
@@ -15,7 +15,7 @@ cd rails-core
 cp .env.example .env
 ```
 
-Set `NEON_API_KEY` in `.env` ([Neon API keys](https://neon.tech/docs/manage/api-keys)) so bootstrap can fill the database URLs, **or** set `USERS_DATABASE_URL`, `ACCOUNTS_DATABASE_URL`, and `LEDGER_DATABASE_URL` manually. Optional Neon-related keys are listed in `.env.example`.
+Set `NEON_API_KEY` in `.env` ([Neon API keys](https://neon.tech/docs/manage/api-keys)) so bootstrap can fill the database URLs, **or** set `USERS_DATABASE_URL`, `ACCOUNTS_DATABASE_URL`, and `LEDGER_DATABASE_URL` manually. Optional Neon-related keys are listed in `.env.example`. Console deep links in the printed table are shortened with Bitly if configured, otherwise **is.gd** (stdlib HTTP); use `NEON_CONSOLE_NO_PUBLIC_SHORTENER=yes` to skip is.gd.
 
 ## 3. Run everything
 
@@ -23,7 +23,7 @@ Set `NEON_API_KEY` in `.env` ([Neon API keys](https://neon.tech/docs/manage/api-
 make dev
 ```
 
-Wait for first-time `cargo`/`bundle` downloads. Then open:
+Wait for first-time `cargo`/`bundle` (and the post-start health wait). Then open:
 
 - **Gateway:** [http://localhost:8080/](http://localhost:8080/) (redirects to `/docs/`)
 - **Static docs:** [http://localhost:8080/docs/](http://localhost:8080/docs/)
@@ -43,17 +43,17 @@ Read [architecture.md](architecture.md) for the one-page diagram and boundaries.
 With the stack still running:
 
 ```bash
-make health   # gateway: /users/health, /accounts/health, /ledger/health + /docs/
+make health   # gateway: /health, /users/health, /accounts/health, /ledger/health + /docs/
 make test     # health JSON checks + full users → accounts → ledger HTTP flow
 ```
 
 `make test` expects the gateway at `http://127.0.0.1:8080` unless you set `GATEWAY_URL`.
 
-## 6. Stop / reset containers
+## 6. Logs, stop / reset containers
 
 ```bash
-make reset
-# or
+make logs     # follow all service logs (requires .env)
+make reset    # or: make stop
 ./scripts/reset.sh
 ```
 

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -30,6 +30,12 @@ http {
         # listen port 80 and become http://localhost/docs/ (wrong). Preserve client Host + port.
         absolute_redirect off;
 
+        # Liveness for the gateway itself (nginx static; does not probe backends).
+        location = /health {
+            default_type application/json;
+            return 200 '{"status":"healthy"}';
+        }
+
         # Public API surface (path prefix stripped when forwarding)
         location /users/ {
             proxy_pass http://users_upstream/;

--- a/scripts/lib/health_check.py
+++ b/scripts/lib/health_check.py
@@ -13,39 +13,45 @@ def _curl_body(url: str) -> tuple[int, str]:
         capture_output=True,
         text=True,
     )
-    return r.returncode, r.stdout
+    return r.returncode, r.stdout or ""
 
 
-def _check_health_json(url: str, label: str) -> bool:
+def _check_health_json(url: str, label: str, *, quiet: bool) -> bool:
     code, body = _curl_body(url)
     if code != 0:
-        print(f"FAIL {label} {url} (curl exit {code})", file=sys.stderr)
+        if not quiet:
+            print(f"FAIL {label} {url} (curl exit {code})", file=sys.stderr)
         return False
     try:
         obj = json.loads(body)
     except json.JSONDecodeError:
-        print(f"FAIL {label} {url} (invalid JSON)", file=sys.stderr)
+        if not quiet:
+            print(f"FAIL {label} {url} (invalid JSON)", file=sys.stderr)
         return False
     # Rust services use "healthy"; ledger uses "ok" — both mean up.
     if obj.get("status") not in ("ok", "healthy"):
-        print(
-            f"FAIL {label} {url} (expected status ok|healthy, got {obj.get('status')!r})",
-            file=sys.stderr,
-        )
+        if not quiet:
+            print(
+                f"FAIL {label} {url} (expected status ok|healthy, got {obj.get('status')!r})",
+                file=sys.stderr,
+            )
         return False
-    print(f"OK  {label} {url}")
+    if not quiet:
+        print(f"OK  {label} {url}")
     return True
 
 
 def main() -> int:
+    quiet = "--quiet" in sys.argv
     base = os.environ.get("GATEWAY_URL", "http://127.0.0.1:8080").rstrip("/")
     failures = 0
     for path, label in (
+        (f"{base}/health", "gateway health"),
         (f"{base}/users/health", "users health"),
         (f"{base}/accounts/health", "accounts health"),
         (f"{base}/ledger/health", "ledger health"),
     ):
-        if not _check_health_json(path, label):
+        if not _check_health_json(path, label, quiet=quiet):
             failures += 1
 
     docs = f"{base}/docs/"
@@ -55,9 +61,11 @@ def main() -> int:
         text=True,
     )
     if r.returncode == 0:
-        print(f"OK  docs static {docs}")
+        if not quiet:
+            print(f"OK  docs static {docs}")
     else:
-        print(f"FAIL docs static {docs}", file=sys.stderr)
+        if not quiet:
+            print(f"FAIL docs static {docs}", file=sys.stderr)
         failures += 1
 
     return 1 if failures else 0

--- a/scripts/lib/neon_bootstrap.py
+++ b/scripts/lib/neon_bootstrap.py
@@ -72,6 +72,11 @@ def dotenv_lines(text: str) -> list[str]:
     return text.splitlines()
 
 
+def _env_truthy(env: dict[str, str], key: str) -> bool:
+    v = os.environ.get(key, "").strip().lower() or env.get(key, "").strip().lower()
+    return v in ("1", "yes", "true", "on")
+
+
 def is_placeholder_database_url(url: str) -> bool:
     u = url.strip()
     if not u.startswith("postgresql://") and not u.startswith("postgres://"):
@@ -87,9 +92,49 @@ def urls_configured(env: dict[str, str]) -> bool:
     return True
 
 
-def _bitly_shorten(long_url: str, access_token: str) -> str | None:
-    """Return a bit.ly (or configured domain) short link, or None on failure."""
-    body = json.dumps({"long_url": long_url}).encode("utf-8")
+def _bitly_fetch_default_group_guid(access_token: str) -> str | None:
+    """Resolve a Bitly group_guid via GET /v4/groups (required by many shorten calls)."""
+    req = urllib.request.Request(
+        "https://api-ssl.bitly.com/v4/groups",
+        headers={"Authorization": f"Bearer {access_token}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310 — fixed Bitly API URL
+            raw = resp.read().decode("utf-8")
+        data = json.loads(raw) if raw else {}
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError):
+        return None
+    groups = data.get("groups") if isinstance(data, dict) else None
+    if not isinstance(groups, list) or not groups:
+        return None
+    for g in groups:
+        if isinstance(g, dict) and g.get("is_active") is True:
+            gid = g.get("guid")
+            if isinstance(gid, str) and gid.strip():
+                return gid.strip()
+    first = groups[0]
+    if isinstance(first, dict):
+        gid = first.get("guid")
+        if isinstance(gid, str) and gid.strip():
+            return gid.strip()
+    return None
+
+
+def _bitly_shorten(
+    long_url: str,
+    access_token: str,
+    *,
+    group_guid: str | None,
+) -> str | None:
+    """Return a bit.ly short link, or None on failure."""
+    payload: dict[str, Any] = {
+        "long_url": long_url,
+        "domain": "bit.ly",
+    }
+    if group_guid:
+        payload["group_guid"] = group_guid
+    body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         "https://api-ssl.bitly.com/v4/shorten",
         data=body,
@@ -112,14 +157,52 @@ def _bitly_shorten(long_url: str, access_token: str) -> str | None:
     return None
 
 
-def shorten_https_url(url: str, bitly_token: str | None) -> str:
-    """If `url` is https and BITLY token is set, replace with a Bitly short link when possible."""
+def _isgd_shorten(url: str) -> str | None:
+    """Shorten via is.gd public API (no API key). See https://is.gd/developers.php — do not use for secrets."""
+    q = urllib.parse.urlencode({"format": "simple", "url": url})
+    api = f"https://is.gd/create.php?{q}"
+    req = urllib.request.Request(
+        api,
+        method="GET",
+        headers={
+            "User-Agent": (
+                "rails-core-neon-bootstrap/1 "
+                "(https://github.com/railsinfra/rails-core; Neon console deep links only)"
+            ),
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310 — fixed is.gd API URL
+            body = resp.read().decode("utf-8").strip()
+    except (urllib.error.URLError, UnicodeDecodeError, TimeoutError):
+        return None
+    if body.startswith("Error:"):
+        return None
+    if body.startswith("https://"):
+        return body
+    if body.startswith("http://is.gd/") or body.startswith("http://v.gd/"):
+        return "https://" + body[len("http://") :]
+    return None
+
+
+def shorten_https_url(
+    url: str,
+    bitly_token: str | None,
+    *,
+    group_guid: str | None = None,
+    allow_public_shortener: bool = True,
+) -> str:
+    """Shorten https URLs for display: Bitly when configured, else is.gd (unless disabled)."""
     if not url or url == "—" or not url.startswith("https://"):
         return url
     token = (bitly_token or "").strip()
-    if not token:
-        return url
-    short = _bitly_shorten(url, token)
+    short: str | None = None
+    if token:
+        short = _bitly_shorten(url, token, group_guid=group_guid)
+        if not short and group_guid is not None:
+            short = _bitly_shorten(url, token, group_guid=None)
+    if not short and allow_public_shortener:
+        short = _isgd_shorten(url)
     return short if short else url
 
 
@@ -130,11 +213,11 @@ def neon_console_project_url(project_id: str) -> str:
 
 
 def neon_console_branch_database_url(project_id: str, branch_id: str, database_name: str) -> str:
-    """Deep link to the branch; `database` query may pre-select DB in SQL Editor (ignored if unsupported)."""
+    """Deep link to branch Tables for `database` (Neon Console path …/branches/…/tables?database=…)."""
     pid = urllib.parse.quote(project_id, safe="")
     bid = urllib.parse.quote(branch_id, safe="")
     q = urllib.parse.urlencode({"database": database_name})
-    return f"{NEON_CONSOLE_ORIGIN}/app/projects/{pid}/branches/{bid}?{q}"
+    return f"{NEON_CONSOLE_ORIGIN}/app/projects/{pid}/branches/{bid}/tables?{q}"
 
 
 def _print_dev_credentials_table(rows: list[tuple[str, str, str]]) -> None:
@@ -623,6 +706,13 @@ def main() -> int:
             os.environ.get("BITLY_ACCESS_TOKEN", "").strip()
             or final.get("BITLY_ACCESS_TOKEN", "").strip()
         ) or None
+        bitly_group = (
+            os.environ.get("BITLY_GROUP_GUID", "").strip()
+            or final.get("BITLY_GROUP_GUID", "").strip()
+        ) or None
+        if bitly and not bitly_group:
+            bitly_group = _bitly_fetch_default_group_guid(bitly)
+        allow_public = not _env_truthy(final, "NEON_CONSOLE_NO_PUBLIC_SHORTENER")
         cred_rows: list[tuple[str, str, str]] = []
         for env_key, db_name in SERVICE_DBS:
             u = final.get(env_key, "").strip()
@@ -630,7 +720,12 @@ def main() -> int:
                 continue
             if project_id and branch_id:
                 console_url = neon_console_branch_database_url(project_id, branch_id, db_name)
-                console_url = shorten_https_url(console_url, bitly)
+                console_url = shorten_https_url(
+                    console_url,
+                    bitly,
+                    group_guid=bitly_group,
+                    allow_public_shortener=allow_public,
+                )
             else:
                 console_url = "—"
             cred_rows.append((env_key, db_name, console_url))
@@ -639,7 +734,15 @@ def main() -> int:
         print("Neon project:", project_name)
         if project_id:
             proj_console = neon_console_project_url(project_id)
-            print("Neon project (console):", shorten_https_url(proj_console, bitly))
+            print(
+                "Neon project (console):",
+                shorten_https_url(
+                    proj_console,
+                    bitly,
+                    group_guid=bitly_group,
+                    allow_public_shortener=allow_public,
+                ),
+            )
         print("Compose can start; database URLs were written to .env (merged with your other variables).")
         return 0
 

--- a/scripts/lib/print_vendor_services_check.py
+++ b/scripts/lib/print_vendor_services_check.py
@@ -2,16 +2,22 @@
 """Print vendored service directory check as a tabulate table (colored when TTY)."""
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
-_LIB_DIR = Path(__file__).resolve().parent
-if str(_LIB_DIR) not in sys.path:
-    sys.path.insert(0, str(_LIB_DIR))
-
 from tabulate import tabulate
 
-from read_manifest import paths_from_manifest
+_LIB_DIR = Path(__file__).resolve().parent
+_read_manifest_path = _LIB_DIR / "read_manifest.py"
+_spec = importlib.util.spec_from_file_location(
+    "_rails_core_read_manifest", _read_manifest_path
+)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"cannot load {_read_manifest_path}")
+_read_manifest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_read_manifest)
+paths_from_manifest = _read_manifest.paths_from_manifest
 
 _GREEN = "\033[32m"
 _RED = "\033[31m"

--- a/scripts/lib/wait_for_stack.py
+++ b/scripts/lib/wait_for_stack.py
@@ -1,0 +1,96 @@
+"""Poll gateway health until the full stack is ready or timeout (used by `make dev`)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _run_health_check(py: str, health_script: Path, *, quiet: bool) -> int:
+    args = [py, str(health_script)]
+    if quiet:
+        args.append("--quiet")
+    return subprocess.run(args, capture_output=False, text=True).returncode
+
+
+def _print_tail_logs(repo: Path, env_file: Path) -> None:
+    print("\n--- Last 120 lines from all services (docker compose logs) ---\n", file=sys.stderr)
+    subprocess.run(
+        ["docker", "compose", "--env-file", str(env_file), "logs", "--tail=120"],
+        cwd=str(repo),
+        check=False,
+    )
+
+
+def main() -> int:
+    repo = os.environ.get("RAILS_CORE_ROOT")
+    if not repo:
+        print("error: RAILS_CORE_ROOT is not set", file=sys.stderr)
+        return 1
+    repo_path = Path(repo).resolve()
+    env_file = repo_path / ".env"
+    if not env_file.is_file():
+        print(f"error: missing {env_file}", file=sys.stderr)
+        return 1
+
+    health_script = repo_path / "scripts" / "lib" / "health_check.py"
+    if not health_script.is_file():
+        print(f"error: missing {health_script}", file=sys.stderr)
+        return 1
+
+    timeout_s = float(os.environ.get("DEV_WAIT_TIMEOUT_SEC", "900"))
+    interval_s = float(os.environ.get("DEV_WAIT_INTERVAL_SEC", "5"))
+    deadline = time.monotonic() + timeout_s
+    py = sys.executable
+
+    print(
+        f"Waiting for all health checks (timeout {int(timeout_s)}s, every {int(interval_s)}s)…",
+        flush=True,
+    )
+    time.sleep(min(interval_s, 8.0))
+
+    while time.monotonic() < deadline:
+        code = _run_health_check(py, health_script, quiet=True)
+        if code == 0:
+            print("\nAll health checks passed:\n", flush=True)
+            _run_health_check(py, health_script, quiet=False)
+            print("\nRails-Core is running\n", flush=True)
+            print("Service URLs (via gateway on port 8080):\n", flush=True)
+            subprocess.run(
+                [py, str(repo_path / "scripts" / "lib" / "print_gateway_hints.py")],
+                check=False,
+            )
+            print(
+                "\nDev credentials and DB URLs were printed earlier by bootstrap when applicable.\n"
+                "Stream container logs with: make logs\n"
+                "Stop the stack with: make stop   (or: make reset)\n",
+                flush=True,
+            )
+            return 0
+        remaining = int(deadline - time.monotonic())
+        if remaining > 0:
+            print(
+                f"Health checks not ready yet ({remaining}s left)…",
+                flush=True,
+            )
+        time.sleep(interval_s)
+
+    print(
+        "\nerror: timed out waiting for stack health. "
+        "Running a verbose health check once; then compose logs.",
+        file=sys.stderr,
+    )
+    _run_health_check(py, health_script, quiet=False)
+    print("", file=sys.stderr)
+    _print_tail_logs(repo_path, env_file)
+    print(
+        "\nTip: fix the issue, then `make reset` and `make dev` again, or run `make health` while containers stay up.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements RAI-10 developer UX: detached Compose, stack health wait, `make logs`/`make stop`, Docker healthchecks, gateway `/health`, and Neon bootstrap console link fixes.

## Changes
- **Compose / Make:** `restart` + per-service healthchecks; gateway starts after apps healthy; `make dev` runs `up -d --build` then `wait_for_stack.py`; `make health` includes gateway; optional `DEV_WAIT_*` env vars.
- **Neon bootstrap:** console URLs use `/branches/.../tables?database=`; Bitly uses `group_guid` + domain; is.gd fallback unless `NEON_CONSOLE_NO_PUBLIC_SHORTENER`; vendor check loads `read_manifest` without `sys.path` hacks.

Closes RAI-10.