### PR TITLE
ci(sonarqube): add SonarCloud analysis to pull request workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,44 @@ jobs:
           working-directory: services/ledger-service
       - run: bundle exec rails db:test:prepare test
 
+  sonarqube:
+    name: SonarQube
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RUST_VERSION: stable
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            services/users-service -> target
+            services/accounts-service -> target
+
+      - name: Run Rust tests (users-service)
+        working-directory: services/users-service
+        run: cargo test --locked
+
+      - name: Run Rust tests (accounts-service)
+        working-directory: services/accounts-service
+        run: cargo test --locked
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   docker-builds:
     name: Dockerfile build (${{ matrix.service }})
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+sonar.projectKey=railsinfra_rails-core
+sonar.organization=railsinfra
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=rails-core
+sonar.projectVersion=0.1.0
+
+# Paths are relative to this file. Replace "\" by "/" on Windows.
+sonar.sources=services/users-service,services/accounts-service,services/ledger-service/app,services/ledger-service/lib
+
+# Keep generated artifacts out of analysis.
+sonar.exclusions=**/target/**,**/.sqlx/**,**/vendor/**,**/tmp/**,**/.git/**
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- Add a `sonarqube` CI job (same-repo PRs only) with full clone, protoc, rust-cache, dual Rust `cargo test`, then SonarSource scan action v6 using `SONAR_TOKEN`.
- Add `sonar-project.properties` for the monorepo (Rust services + ledger `app`/`lib`), exclusions, and `railsinfra` SonarCloud project binding.