### PR TITLE
ci(sonarqube): import test coverage into SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,26 @@ jobs:
     name: SonarQube
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     permissions:
       contents: read
     env:
       RUST_VERSION: stable
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,6 +125,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
+          components: llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -116,13 +133,33 @@ jobs:
             services/users-service -> target
             services/accounts-service -> target
 
-      - name: Run Rust tests (users-service)
-        working-directory: services/users-service
-        run: cargo test --locked
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
-      - name: Run Rust tests (accounts-service)
+      - name: Rust coverage (users-service)
+        working-directory: services/users-service
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/coverage-rust"
+          cargo llvm-cov test --locked --lcov --output-path "${GITHUB_WORKSPACE}/coverage-rust/users.lcov.info"
+
+      - name: Rust coverage (accounts-service)
         working-directory: services/accounts-service
-        run: cargo test --locked
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/coverage-rust"
+          cargo llvm-cov test --locked --lcov --output-path "${GITHUB_WORKSPACE}/coverage-rust/accounts.lcov.info"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: services/ledger-service
+
+      - name: Ledger coverage (Rails tests)
+        working-directory: services/ledger-service
+        env:
+          COVERAGE: "true"
+        run: bundle exec rails db:test:prepare test
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ target/
 services/ledger-service/log/
 services/ledger-service/tmp/
 services/ledger-service/storage/
+services/ledger-service/coverage/
+
+# CI / Sonar (Rust LCOV at repo root)
+coverage-rust/

--- a/services/ledger-service/Gemfile
+++ b/services/ledger-service/Gemfile
@@ -63,6 +63,11 @@ group :development, :test do
   gem "minitest", "~> 5.1"
 end
 
+group :test do
+  # JSON coverage for SonarCloud (simplecov pulls simplecov_json_formatter).
+  gem "simplecov", "~> 0.22", require: false
+end
+
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"

--- a/services/ledger-service/Gemfile.lock
+++ b/services/ledger-service/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -273,6 +274,12 @@ GEM
     sentry-ruby (6.3.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.0)
@@ -314,6 +321,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.4)
   sentry-rails
   sentry-ruby
+  simplecov (~> 0.22)
   tzinfo-data
   uuidtools
 

--- a/services/ledger-service/test/test_helper.rb
+++ b/services/ledger-service/test/test_helper.rb
@@ -1,7 +1,17 @@
 ENV["RAILS_ENV"] ||= "test"
+
+if ENV["COVERAGE"] == "true"
+  require "simplecov"
+  require "simplecov_json_formatter"
+  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+  SimpleCov.start "rails" do
+    add_filter "/test/"
+  end
+end
+
 require_relative "../config/environment"
 require "rails/test_help"
 
 class ActiveSupport::TestCase
-  parallelize(workers: :number_of_processors)
+  parallelize(workers: ENV["COVERAGE"] == "true" ? 1 : :number_of_processors)
 end

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,14 @@ sonar.projectVersion=0.1.0
 sonar.sources=services/users-service,services/accounts-service,services/ledger-service/app,services/ledger-service/lib
 
 # Keep generated artifacts out of analysis.
-sonar.exclusions=**/target/**,**/.sqlx/**,**/vendor/**,**/tmp/**,**/.git/**
+sonar.exclusions=**/target/**,**/.sqlx/**,**/vendor/**,**/tmp/**,**/.git/**,coverage-rust/**,**/coverage/**
+
+# Coverage reports (produced in CI before sonar-scanner).
+sonar.rust.lcov.reportPaths=coverage-rust/users.lcov.info,coverage-rust/accounts.lcov.info
+sonar.ruby.coverage.reportPaths=services/ledger-service/coverage/coverage.json
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+
+# Python analyzer (e.g. scripts/ if included in sonar.sources); align with your runtime / CI image.
+sonar.python.version=3.12


### PR DESCRIPTION
## Summary

- Extend the Sonar CI job to emit Rust LCOV (cargo-llvm-cov), ledger SimpleCov JSON (COVERAGE=true), then upload with Sonar.
- Configure `sonar-project.properties` coverage paths and gitignore for `coverage-rust/` and ledger `coverage/`.