### PR TITLE
fix(ledger): remove hardcoded DATABASE_URL from hardened ledger script

### DIFF
--- a/services/ledger-service/test/standalone_scripts_no_hardcoded_database_urls_test.rb
+++ b/services/ledger-service/test/standalone_scripts_no_hardcoded_database_urls_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Static guard: no full Rails stack (avoids DB boot for this file alone).
+require "minitest/autorun"
+
+class StandaloneScriptsNoHardcodedDatabaseUrlsTest < Minitest::Test
+  def test_test_hardened_ledger_rb_does_not_embed_postgres_credentials_in_a_connection_url
+    root = File.expand_path("..", __dir__)
+    path = File.join(root, "test_hardened_ledger.rb")
+    skip "test_hardened_ledger.rb is not present" unless File.file?(path)
+
+    body = File.read(path)
+    non_comment = body.lines.reject { |line| line.lstrip.start_with?("#") }.join
+
+    refute_match(
+      %r{postgresql://[A-Za-z0-9_.-]+:[^"'\s/@]+@}i,
+      non_comment,
+      "Do not hardcode DATABASE_URL with a password; use ENV[\"DATABASE_URL\"] or the localhost default from config/database.yml."
+    )
+  end
+end

--- a/services/ledger-service/test_hardened_ledger.rb
+++ b/services/ledger-service/test_hardened_ledger.rb
@@ -5,8 +5,8 @@ require 'bundler/setup'
 require 'active_record'
 require 'pg'
 
-# Load database config
-DATABASE_URL = "postgresql://neondb_owner:npg_6LTzUMvFi0Qe@ep-icy-mouse-acf5xu9j-pooler.sa-east-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
+# Load database config — never commit credentials in this repo. Set DATABASE_URL (see config/database.yml).
+DATABASE_URL = ENV["DATABASE_URL"] || "postgresql://localhost:5432/ledger_test"
 
 ActiveRecord::Base.establish_connection(
   adapter: 'postgresql',


### PR DESCRIPTION
## Summary

Removes a committed Neon `DATABASE_URL` from `services/ledger-service/test_hardened_ledger.rb` (GitScan disclosure). The script now uses `ENV["DATABASE_URL"]` with the same localhost default as `config/database.yml` for the test database.

Adds a small static Minitest that fails if a `postgresql://user:password@` literal appears in that script again.

## Post-merge (ops)

- Rotate/revoke the Neon credentials that were exposed in git history.
- Mark the GitScan finding resolved after the default branch is clean and credentials are rotated.

## Testing

- `ruby services/ledger-service/test/standalone_scripts_no_hardcoded_database_urls_test.rb`
- `bundle exec rails test test/standalone_scripts_no_hardcoded_database_urls_test.rb` (from `services/ledger-service`)