### PR TITLE
feat(users-service): add POST /api/v1/users for SDK provisioning

### DIFF
--- a/services/users-service/src/routes/mod.rs
+++ b/services/users-service/src/routes/mod.rs
@@ -49,6 +49,7 @@ pub fn register_routes(db: Db, grpc: GrpcClients, email: Option<EmailService>) -
         .route("/api/v1/api-keys", post(apikey::create_api_key))
         .route("/api/v1/api-keys", get(apikey::list_api_keys))
         .route("/api/v1/api-keys/:api_key_id/revoke", post(apikey::revoke_api_key))
+        .route("/api/v1/users", post(user::create_sdk_user))
         .route("/api/v1/me", get(user::me));
 
     public

--- a/services/users-service/src/routes/user.rs
+++ b/services/users-service/src/routes/user.rs
@@ -1,14 +1,190 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHasher};
+use axum::extract::ConnectInfo;
+use axum::http::HeaderMap;
 use axum::{Json, extract::State};
-use uuid::Uuid;
-use crate::error::AppError;
-use crate::routes::AppState;
-use crate::auth::AuthContext;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sqlx::Row;
+use uuid::Uuid;
+
+use crate::audit_emit;
+use crate::auth::{ApiKeyOnlyContext, AuthContext};
+use crate::error::{AppError, DUPLICATE_EMAIL_MESSAGE};
+use crate::grpc::audit_proto::ActorType;
+use crate::routes::AppState;
 
 /// Normalize email for storage and lookup: trim and lowercase.
 pub(crate) fn normalize_email(email: &str) -> String {
     email.trim().to_lowercase()
+}
+
+const SDK_USER_MIN_PASSWORD_LEN: usize = 8;
+
+/// Validates SDK `POST /api/v1/users` body (trimmed names, normalized email, password length).
+pub(crate) fn validate_sdk_user_payload(
+    email: &str,
+    first_name: &str,
+    last_name: &str,
+    password: &str,
+) -> Result<(String, String, String), AppError> {
+    let email = normalize_email(email);
+    if email.is_empty() {
+        return Err(AppError::BadRequest("Email is required.".to_string()));
+    }
+    let first_name = first_name.trim().to_string();
+    if first_name.is_empty() {
+        return Err(AppError::BadRequest("First name is required.".to_string()));
+    }
+    let last_name = last_name.trim().to_string();
+    if last_name.is_empty() {
+        return Err(AppError::BadRequest("Last name is required.".to_string()));
+    }
+    if password.len() < SDK_USER_MIN_PASSWORD_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Password must be at least {SDK_USER_MIN_PASSWORD_LEN} characters."
+        )));
+    }
+    Ok((email, first_name, last_name))
+}
+
+#[derive(Deserialize)]
+pub struct CreateSdkUserRequest {
+    pub email: String,
+    pub first_name: String,
+    pub last_name: String,
+    pub password: String,
+}
+
+#[derive(Serialize)]
+pub struct CreateSdkUserResponse {
+    pub status: String,
+    pub user_id: Uuid,
+}
+
+async fn create_sdk_user_inner(
+    state: AppState,
+    ctx: ApiKeyOnlyContext,
+    Json(payload): Json<CreateSdkUserRequest>,
+) -> Result<CreateSdkUserResponse, AppError> {
+    let (email, first_name, last_name) = validate_sdk_user_payload(
+        &payload.email,
+        &payload.first_name,
+        &payload.last_name,
+        &payload.password,
+    )?;
+
+    let exists = sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)")
+        .bind(&email)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|_| AppError::Internal)?;
+    if exists {
+        return Err(AppError::Conflict(DUPLICATE_EMAIL_MESSAGE.to_string()));
+    }
+
+    let user_id = Uuid::new_v4();
+    let salt = SaltString::generate(&mut OsRng);
+    let password_hash = Argon2::default()
+        .hash_password(payload.password.as_bytes(), &salt)
+        .map_err(|_| AppError::Internal)?
+        .to_string();
+
+    sqlx::query(
+        r#"INSERT INTO users (
+            id, business_id, environment_id, first_name, last_name, email, password_hash,
+            role, status, created_at, updated_at, created_by_user_id, created_by_api_key_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'user', 'active', NOW(), NOW(), NULL, $8)"#,
+    )
+    .bind(&user_id)
+    .bind(&ctx.business_id)
+    .bind(&ctx.environment_id)
+    .bind(&first_name)
+    .bind(&last_name)
+    .bind(&email)
+    .bind(&password_hash)
+    .bind(&ctx.api_key_id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| {
+        if let Some(db_err) = e.as_database_error() {
+            if db_err.message().contains("unique_email") {
+                return AppError::Conflict(DUPLICATE_EMAIL_MESSAGE.to_string());
+            }
+        }
+        AppError::Internal
+    })?;
+
+    Ok(CreateSdkUserResponse {
+        status: "active".to_string(),
+        user_id,
+    })
+}
+
+pub async fn create_sdk_user(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    ctx: ApiKeyOnlyContext,
+    Json(payload): Json<CreateSdkUserRequest>,
+) -> Result<Json<CreateSdkUserResponse>, AppError> {
+    const PATH: &str = "/api/v1/users";
+    const ACTION: &str = "users.sdk.user.create";
+    let business_id = ctx.business_id;
+    let api_key_id = ctx.api_key_id;
+    let out = create_sdk_user_inner(state.clone(), ctx, Json(payload)).await;
+    let mut meta = HashMap::new();
+    meta.insert("api_key_id".to_string(), api_key_id.to_string());
+    match &out {
+        Ok(body) => {
+            audit_emit::emit_users_mutation(
+                &state.grpc,
+                &headers,
+                &peer,
+                "POST",
+                PATH,
+                ACTION,
+                business_id,
+                ActorType::Anonymous,
+                "",
+                vec![],
+                "user",
+                body.user_id,
+                200,
+                None,
+                meta,
+            )
+            .await;
+        }
+        Err(e) => {
+            meta.insert(
+                "http_status".into(),
+                audit_emit::http_status_for_error(e).to_string(),
+            );
+            audit_emit::emit_users_mutation(
+                &state.grpc,
+                &headers,
+                &peer,
+                "POST",
+                PATH,
+                ACTION,
+                business_id,
+                ActorType::Anonymous,
+                "",
+                vec![],
+                "user",
+                Uuid::nil(),
+                audit_emit::http_status_for_error(e),
+                Some(audit_emit::truncate_reason(&e.to_string())),
+                meta,
+            )
+            .await;
+        }
+    }
+    out.map(Json)
 }
 
 #[derive(Serialize)]
@@ -154,8 +330,8 @@ pub async fn me(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_email;
-    use crate::error::DUPLICATE_EMAIL_MESSAGE;
+    use super::{normalize_email, validate_sdk_user_payload};
+    use crate::error::{AppError, DUPLICATE_EMAIL_MESSAGE};
 
     #[test]
     fn normalize_email_trims_and_lowercases() {
@@ -172,5 +348,38 @@ mod tests {
             DUPLICATE_EMAIL_MESSAGE.contains("signing in") || DUPLICATE_EMAIL_MESSAGE.contains("reset"),
             "Message should suggest sign in or password reset"
         );
+    }
+
+    #[test]
+    fn validate_sdk_user_payload_rejects_empty_email() {
+        let e = validate_sdk_user_payload("  ", "A", "B", "password123!").unwrap_err();
+        assert!(matches!(e, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_sdk_user_payload_rejects_empty_first_name() {
+        let e = validate_sdk_user_payload("a@b.com", "  ", "B", "password123!").unwrap_err();
+        assert!(matches!(e, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_sdk_user_payload_rejects_empty_last_name() {
+        let e = validate_sdk_user_payload("a@b.com", "A", "\t", "password123!").unwrap_err();
+        assert!(matches!(e, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_sdk_user_payload_rejects_short_password() {
+        let e = validate_sdk_user_payload("a@b.com", "A", "B", "short7!").unwrap_err();
+        assert!(matches!(e, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn validate_sdk_user_payload_accepts_valid_input() {
+        let (em, f, l) =
+            validate_sdk_user_payload("  User@EX.com ", "  Pat ", " Lee ", "password123!").unwrap();
+        assert_eq!(em, "user@ex.com");
+        assert_eq!(f, "Pat");
+        assert_eq!(l, "Lee");
     }
 }

--- a/services/users-service/tests/integration_db.rs
+++ b/services/users-service/tests/integration_db.rs
@@ -133,7 +133,7 @@ fn register_payload(email: &str, admin_password: &str) -> RegisterBusinessReques
 
 #[tokio::test]
 async fn db_init_succeeds_when_database_url_valid() {
-    let pool = match test_pool().await {
+    let _pool = match test_pool().await {
         Some(p) => p,
         None => {
             eprintln!("DATABASE_URL not set; skipping db_init_succeeds_when_database_url_valid.");
@@ -146,8 +146,6 @@ async fn db_init_succeeds_when_database_url_valid() {
         .fetch_one(&fresh)
         .await
         .expect("ping");
-    drop(fresh);
-    drop(pool);
 }
 
 #[tokio::test]

--- a/services/users-service/tests/integration_db.rs
+++ b/services/users-service/tests/integration_db.rs
@@ -624,6 +624,7 @@ async fn sdk_create_user_via_api_key_login_duplicate_and_validation() {
     };
 
     let admin_email = format!("admin+{}@example.com", Uuid::new_v4());
+    let admin_pw = unique_test_password();
     let state = AppState {
         db: pool.clone(),
         grpc: grpc_none(),
@@ -634,7 +635,7 @@ async fn sdk_create_user_via_api_key_login_duplicate_and_validation() {
         State(state.clone()),
         hdr_empty(),
         test_connect_info(),
-        Json(register_payload(&admin_email)),
+        Json(register_payload(&admin_email, &admin_pw)),
     )
     .await
     .expect("register_business");
@@ -645,7 +646,7 @@ async fn sdk_create_user_via_api_key_login_duplicate_and_validation() {
         test_connect_info(),
         Json(LoginRequest {
             email: admin_email.clone(),
-            password: "password123!".into(),
+            password: admin_pw.clone(),
             environment_id: None,
         }),
     )

--- a/services/users-service/tests/integration_db.rs
+++ b/services/users-service/tests/integration_db.rs
@@ -37,7 +37,7 @@ use users_service::routes::business::{register_business, RegisterBusinessRequest
 use users_service::routes::password_reset::{
     request_password_reset, reset_password, RequestPasswordResetRequest, ResetPasswordRequest,
 };
-use users_service::routes::user::me;
+use users_service::routes::user::{create_sdk_user, me, CreateSdkUserRequest};
 use users_service::routes::{register_routes, AppState};
 use users_service::test_support::test_connect_info;
 
@@ -600,6 +600,190 @@ async fn beta_apply_conflict_on_duplicate_email() {
 }
 
 #[tokio::test]
+async fn sdk_create_user_via_api_key_login_duplicate_and_validation() {
+    let _lock = env_lock();
+    std::env::set_var(JWT_SECRET_ENV, "integration_test_jwt_secret");
+    std::env::set_var(API_KEY_HASH_SECRET_ENV, "integration_test_api_key_hash");
+
+    let pool = match test_pool().await {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "DATABASE_URL not set; skipping sdk_create_user_via_api_key_login_duplicate_and_validation."
+            );
+            return;
+        }
+    };
+
+    let admin_email = format!("admin+{}@example.com", Uuid::new_v4());
+    let state = AppState {
+        db: pool.clone(),
+        grpc: grpc_none(),
+        email: None,
+    };
+
+    let _ = register_business(
+        State(state.clone()),
+        hdr_empty(),
+        test_connect_info(),
+        Json(register_payload(&admin_email)),
+    )
+    .await
+    .expect("register_business");
+
+    let login_admin = login(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        Json(LoginRequest {
+            email: admin_email.clone(),
+            password: "password123!".into(),
+            environment_id: None,
+        }),
+    )
+    .await
+    .expect("login admin");
+    let access = login_admin.0.access_token.clone();
+    let sandbox_id = login_admin
+        .0
+        .environments
+        .iter()
+        .find(|e| e.r#type == "sandbox")
+        .expect("sandbox environment")
+        .id;
+
+    let mut jwt_parts = empty_request_parts();
+    jwt_parts.headers.insert(
+        header::AUTHORIZATION,
+        format!("Bearer {}", access).parse().unwrap(),
+    );
+    jwt_parts
+        .headers
+        .insert("x-environment-id", sandbox_id.to_string().parse().unwrap());
+    let ctx_admin = AuthContext::from_request_parts(&mut jwt_parts, &state)
+        .await
+        .expect("admin jwt context");
+
+    let key_resp = create_api_key(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        ctx_admin,
+        Json(CreateApiKeyRequest {
+            environment_id: Some(sandbox_id),
+        }),
+    )
+    .await
+    .expect("create_api_key");
+    let plain_key = key_resp.0.key.clone();
+
+    let mut parts = empty_request_parts();
+    parts
+        .headers
+        .insert("x-api-key", plain_key.parse().unwrap());
+    parts
+        .headers
+        .insert("x-environment", "sandbox".parse().unwrap());
+    let api_ctx = ApiKeyOnlyContext::from_request_parts(&mut parts, &state)
+        .await
+        .expect("api key only context");
+
+    let sdk_email = format!("sdk+{}@example.com", Uuid::new_v4());
+    let created = create_sdk_user(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        api_ctx.clone(),
+        Json(CreateSdkUserRequest {
+            email: sdk_email.clone(),
+            first_name: "Sam".into(),
+            last_name: "Sdk".into(),
+            password: "password123!".into(),
+        }),
+    )
+    .await
+    .expect("create sdk user");
+    assert_eq!(created.0.status, "active");
+    assert_ne!(created.0.user_id, Uuid::nil());
+
+    let _ = login(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        Json(LoginRequest {
+            email: sdk_email.clone(),
+            password: "password123!".into(),
+            environment_id: Some(sandbox_id),
+        }),
+    )
+    .await
+    .expect("sdk user login");
+
+    let dup = create_sdk_user(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        api_ctx.clone(),
+        Json(CreateSdkUserRequest {
+            email: sdk_email.clone(),
+            first_name: "Other".into(),
+            last_name: "Person".into(),
+            password: "password123!".into(),
+        }),
+    )
+    .await;
+    assert!(matches!(dup, Err(AppError::Conflict(_))));
+
+    let dup_admin = create_sdk_user(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        api_ctx.clone(),
+        Json(CreateSdkUserRequest {
+            email: admin_email.clone(),
+            first_name: "Dup".into(),
+            last_name: "Admin".into(),
+            password: "password123!".into(),
+        }),
+    )
+    .await;
+    assert!(matches!(dup_admin, Err(AppError::Conflict(_))));
+
+    let short_pw = create_sdk_user(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        api_ctx.clone(),
+        Json(CreateSdkUserRequest {
+            email: format!("short+{}@example.com", Uuid::new_v4()),
+            first_name: "A".into(),
+            last_name: "B".into(),
+            password: "short7!".into(),
+        }),
+    )
+    .await;
+    assert!(matches!(short_pw, Err(AppError::BadRequest(_))));
+
+    let empty_fn = create_sdk_user(
+        State(state.clone()),
+        HeaderMap::new(),
+        test_connect_info(),
+        api_ctx,
+        Json(CreateSdkUserRequest {
+            email: format!("fn+{}@example.com", Uuid::new_v4()),
+            first_name: "   ".into(),
+            last_name: "B".into(),
+            password: "password123!".into(),
+        }),
+    )
+    .await;
+    assert!(matches!(empty_fn, Err(AppError::BadRequest(_))));
+
+    std::env::remove_var(JWT_SECRET_ENV);
+    std::env::remove_var(API_KEY_HASH_SECRET_ENV);
+}
+
+#[tokio::test]
 async fn http_router_health_and_correlation_header() {
     let _lock = env_lock();
     std::env::set_var(JWT_SECRET_ENV, "integration_test_jwt_secret");
@@ -637,6 +821,25 @@ async fn http_router_health_and_correlation_header() {
     let bytes = to_bytes(api.into_body(), 1024 * 64).await.unwrap();
     let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert!(v.get("error").is_some() || v.get("message").is_some());
+
+    let mut users_req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/users")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header("x-environment", "sandbox")
+        .body(Body::from(
+            json!({
+                "email": "router+nokey@example.com",
+                "first_name": "A",
+                "last_name": "B",
+                "password": "password123!"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    users_req.extensions_mut().insert(ConnectInfo(peer));
+    let users = svc.ready().await.unwrap().call(users_req).await.unwrap();
+    assert_eq!(users.status(), StatusCode::UNAUTHORIZED);
 
     std::env::remove_var(JWT_SECRET_ENV);
 }


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/users` on users-service so SDKs can create banking users with an API key and environment headers (same model as other API-key routes).

## Changes

- Handler creates active `user` rows with Argon2 password hashing, `created_by_api_key_id`, and normalized email
- Returns `status` and `user_id`; duplicate email returns conflict; validation errors return 400
- Unit tests for payload validation; integration tests for happy path, login, duplicates, and router 401 without key

## Testing

- `cargo test` in `services/users-service`