### PR TITLE
fix: ledger gRPC port for Railway + root dev deploy workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ RUST_LOG=info
 # Optional — only when running Rust services on the host (not needed for `make dev`):
 # ACCOUNTS_GRPC_URL=http://127.0.0.1:9090
 # USERS_GRPC_URL=http://127.0.0.1:50051
-# LEDGER_GRPC_URL=http://127.0.0.1:50053
+# LEDGER_GRPC_URL=http://127.0.0.1:9090
 
 # Optional — users-service sensitive routes (register/login) require this header when set:
 # INTERNAL_SERVICE_TOKEN_ALLOWLIST=your-dev-token

--- a/.github/workflows/deploy-railway-dev.yml
+++ b/.github/workflows/deploy-railway-dev.yml
@@ -1,0 +1,174 @@
+# Deploy Rust + Rails services to Railway when `develop` moves forward.
+# Workflows under `services/*/.github/workflows/` are not loaded by GitHub Actions; this root file is the source of truth.
+#
+# Requires: repository secret RAILWAY_TOKEN (Railway project token for the dev environment).
+# Deploy uses `railway up --service <name>` from the monorepo root (same layout as nested templates).
+name: Deploy Railway (dev)
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: railway-deploy-dev-${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  RUST_VERSION: stable
+  RUBY_VERSION: "3.3.0"
+
+jobs:
+  users-service:
+    name: users-service → Railway dev
+    runs-on: ubuntu-latest
+    environment: development
+    defaults:
+      run:
+        working-directory: services/users-service
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: services/users-service
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+      - run: cargo test --locked -- --include-ignored
+      - run: npm install -g @railway/cli
+      - name: railway up (users-service)
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set (GitHub → Settings → Secrets and variables → Actions). Use a Railway project token for the dev environment."
+            exit 1
+          fi
+          railway up --service users-service --detach
+
+  accounts-service:
+    name: accounts-service → Railway dev
+    runs-on: ubuntu-latest
+    environment: development
+    defaults:
+      run:
+        working-directory: services/accounts-service
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: services/accounts-service
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+      - run: cargo test --locked -- --include-ignored
+      - run: npm install -g @railway/cli
+      - name: railway up (accounts-service)
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set (GitHub → Settings → Secrets and variables → Actions). Use a Railway project token for the dev environment."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+
+  audit-service:
+    name: audit-service → Railway dev
+    runs-on: ubuntu-latest
+    environment: development
+    defaults:
+      run:
+        working-directory: services/audit-service
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: services/audit-service
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+      - run: cargo test --locked -- --include-ignored
+      - run: npm install -g @railway/cli
+      - name: railway up (audit-service)
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set (GitHub → Settings → Secrets and variables → Actions). Use a Railway project token for the dev environment."
+            exit 1
+          fi
+          set -euo pipefail
+          shopt -s nullglob
+          crates=( "${GITHUB_WORKSPACE}"/*/audit-service )
+          shopt -u nullglob
+          if [ "${#crates[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one */audit-service under the repository root."
+            exit 1
+          fi
+          cd "${crates[0]}"
+          railway up --detach
+
+  ledger-service:
+    name: ledger-service → Railway dev
+    runs-on: ubuntu-latest
+    environment: development
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    defaults:
+      run:
+        working-directory: services/ledger-service
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: services/ledger-service
+      - run: bundle exec rails db:test:prepare test
+      - run: npm install -g @railway/cli
+      - name: railway up (ledger-service)
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set (GitHub → Settings → Secrets and variables → Actions). Use a Railway project token for the dev environment."
+            exit 1
+          fi
+          railway up --service ledger-service --detach

--- a/config/services.json
+++ b/config/services.json
@@ -21,7 +21,7 @@
       "path": "services/ledger-service",
       "language": "ruby",
       "summary": "Double-entry ledger, financial finality",
-      "ports": { "http": 3000, "grpc": 50053 }
+      "ports": { "http": 3000, "grpc": 9090 }
     },
     {
       "id": "audit-service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       PORT: "8080"
       GRPC_PORT: "9090"
       USERS_GRPC_URL: http://users-service:50051
-      LEDGER_GRPC_URL: http://ledger-service:50053
+      LEDGER_GRPC_URL: http://ledger-service:9090
       AUDIT_GRPC_URL: http://audit-service:50054
       RUST_LOG: ${RUST_LOG:-info}
     command: bash -c "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && apt-get install -y -qq protobuf-compiler && cargo run --release"
@@ -117,14 +117,14 @@ services:
       DATABASE_URL: ${LEDGER_DATABASE_URL}
       RAILS_ENV: development
       PORT: "3000"
-      GRPC_PORT: "50053"
+      GRPC_PORT: "9090"
       AUDIT_GRPC_URL: audit-service:50054
     # ledger-db may be empty after Neon bootstrap; create tables before gRPC/Puma.
     # tmp/pids/server.pid is on the host bind mount; a stale file (esp. pid 1) makes Rails exit "already running"
     command: bash -c "rm -f tmp/pids/server.pid && bundle install && bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0 -p 3000"
     expose:
       - "3000"
-      - "50053"
+      - "9090"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS --max-time 5 http://127.0.0.1:3000/health >/dev/null"]
       interval: 15s

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -25,6 +25,7 @@ From `services/accounts-service`:
   - `DATABASE_URL`
   - `PORT`
   - `GRPC_PORT`
+  - `LEDGER_GRPC_URL` (ledger **gRPC** URL, e.g. `http://<ledger-grpc host>.railway.internal:9090` on private networking—not the Rails HTTP URL)
   - `HOST`
   - `RUST_LOG`
 
@@ -48,7 +49,7 @@ From `services/ledger-service`:
 - Deploy service
 - Set variables:
   - `DATABASE_URL`
-  - `GRPC_PORT`
+  - `GRPC_PORT` — defaults to **9090** in-app, matching **`ledger-grpc` `internalPort`** in `railway.toml`. Set only if you change that port.
   - `RAILS_ENV`
   - `LOG_LEVEL`
 

--- a/scripts/deploy-railway.sh
+++ b/scripts/deploy-railway.sh
@@ -53,6 +53,7 @@ deploy_accounts() {
   echo "  DATABASE_URL"
   echo "  PORT"
   echo "  GRPC_PORT"
+  echo "  LEDGER_GRPC_URL"
   echo "  HOST"
   echo "  RUST_LOG"
 }

--- a/services/accounts-service/src/config/settings.rs
+++ b/services/accounts-service/src/config/settings.rs
@@ -42,7 +42,7 @@ impl Settings {
             .unwrap_or(9090);
 
         let ledger_grpc_url = std::env::var(LEDGER_GRPC_URL_ENV)
-            .unwrap_or_else(|_| "http://127.0.0.1:50053".to_string());
+            .unwrap_or_else(|_| "http://127.0.0.1:9090".to_string());
 
         let users_grpc_url = std::env::var(USERS_GRPC_URL_ENV)
             .unwrap_or_else(|_| "http://127.0.0.1:50051".to_string());

--- a/services/accounts-service/src/handlers/health.rs
+++ b/services/accounts-service/src/handlers/health.rs
@@ -17,7 +17,7 @@ pub async fn service_root() -> Json<serde_json::Value> {
 
 fn try_connect_ledger_grpc(endpoint: &str, timeout: Duration) -> bool {
     // Expect an HTTP/HTTPS-style endpoint (tonic Endpoint::from_shared),
-    // e.g. "http://127.0.0.1:50053"
+    // e.g. "http://127.0.0.1:9090"
     let without_scheme = endpoint
         .strip_prefix("http://")
         .or_else(|| endpoint.strip_prefix("https://"))

--- a/services/ledger-service/app/controllers/application_controller.rb
+++ b/services/ledger-service/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::API
   def health
     # Health check should return 200 OK as long as Rails is running
     # gRPC status is informational only - don't fail health check if gRPC isn't ready yet
-    grpc_port = ENV.fetch('GRPC_PORT', 50053).to_i
+    grpc_port = ENV.fetch('GRPC_PORT', 9090).to_i
     grpc_status = 'unknown'
     
     begin

--- a/services/ledger-service/config/initializers/grpc.rb
+++ b/services/ledger-service/config/initializers/grpc.rb
@@ -54,7 +54,7 @@ if (Rails.env.development? || Rails.env.production?) && should_start_grpc
 
     Thread.new do
       begin
-        grpc_port = ENV.fetch('GRPC_PORT', 50053).to_i
+        grpc_port = ENV.fetch('GRPC_PORT', 9090).to_i
         server = GRPC::RpcServer.new
         server.add_http2_port("0.0.0.0:#{grpc_port}", :this_port_is_insecure)
         server.handle(LedgerService.new)


### PR DESCRIPTION
### Summary
- **Ledger** now defaults `GRPC_PORT` to **9090**, matching `ledger-grpc` `internalPort` in `services/ledger-service/railway.toml`, so Railway can reach the listener without a mismatched secret.
- **Dev compose / local defaults** call ledger gRPC at **:9090** (`LEDGER_GRPC_URL`, `accounts-service` default).
- **Docs + deploy script** remind operators to set `LEDGER_GRPC_URL` on accounts in Railway.

### CI / Railway
Nested workflows under `services/*/.github/workflows/` were **never picked up by GitHub Actions**. This adds `.github/workflows/deploy-railway-dev.yml` at the repo root so a **push to `develop`** runs tests (same shape as CI) then `railway up` for users, accounts, audit, and ledger against the `development` GitHub environment.

Ensure **`RAILWAY_TOKEN`** is configured for that environment.