### PR TITLE
fix: ledger Docker build for Railway full-repo snapshot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Build context = repository root (rails-core) for Dockerfiles under services/*/
+# that use COPY services/<name>/...
+
+.git/
+
+# Rust build outputs (large; not needed for ledger image)
+**/target/
+
+# Ledger — keep COPY services/ledger-service/ lean
+services/ledger-service/log/
+services/ledger-service/tmp/
+services/ledger-service/storage/
+services/ledger-service/.bundle/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Build image
         run: |
           if [ "${{ matrix.service }}" = "ledger-service" ]; then
-            docker build -f "services/ledger-service/Dockerfile" "services/ledger-service"
+            docker build -f "services/ledger-service/Dockerfile" .
           else
             # Rust services use path `../audit-service` and build.rs `../../proto`; context must be repo root.
             docker build -f "services/${{ matrix.service }}/Dockerfile" .

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -14,6 +14,32 @@ This guide covers deploying the MVP services to Railway using **gRPC** for inter
 - Railway CLI installed + authenticated
 - Neon database connection strings ready
 
+## Monorepo builds (avoid Railpack “could not determine how to build”)
+
+`rails-core` is a **monorepo**: Dockerfiles live under `services/<name>/`, but Railway often clones the **whole repo** with an **empty “Root Directory”**. In that mode Railpack runs at the repo root, skips nested Dockerfiles, and fails.
+
+Pick **one** approach per service:
+
+### A) Service variable `RAILWAY_DOCKERFILE_PATH` (full repo checkout)
+
+Set on each Railway service (Variables), paths relative to repo root:
+
+| Service | `RAILWAY_DOCKERFILE_PATH` |
+|---------|---------------------------|
+| accounts-service | `services/accounts-service/Dockerfile` |
+| users-service | `services/users-service/Dockerfile` |
+| ledger-service | `services/ledger-service/Dockerfile` |
+
+Then set **Builder** to **Dockerfile** (disable Railpack auto-detect if the UI offers it). Build context remains the **repository root**, which matches these Dockerfiles.
+
+**audit-service** today uses a **crate-local** Dockerfile (`COPY Cargo.toml` from context root). For Railway, either set the service **Root Directory** to `services/audit-service` (isolated monorepo), or refactor that Dockerfile to repo-root context later.
+
+### B) Root directory per service (isolated monorepo)
+
+In Railway → service → **Settings → Root Directory**, set e.g. `services/<service>`. Railway then uses that folder as the build context; only use this if the service’s Dockerfile is written for that **narrow** context. The **ledger** Dockerfile in this repo expects the **monorepo root**—use **A** for ledger unless you maintain a separate crate-local Dockerfile.
+
+Official reference: [Deploying an isolated monorepo](https://docs.railway.app/deployments/monorepo), [Dockerfiles](https://docs.railway.app/builds/dockerfiles).
+
 ## Deploy
 
 ### 1) Deploy Accounts Service

--- a/services/ledger-service/Dockerfile
+++ b/services/ledger-service/Dockerfile
@@ -1,4 +1,10 @@
 # syntax = docker/dockerfile:1
+#
+# Build context must be the **repository root** (rails-core), same contract as
+# `services/accounts-service/Dockerfile` and `services/users-service/Dockerfile`.
+# This allows Railway to clone the full monorepo (empty service root directory) and set:
+#   RAILWAY_DOCKERFILE_PATH=services/ledger-service/Dockerfile
+# (see https://docs.railway.app/builds/dockerfiles and Deploying a Monorepo).
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.3.0
@@ -7,7 +13,6 @@ FROM ruby:$RUBY_VERSION-slim as base
 # Rails app lives here
 WORKDIR /rails
 
-# Set production environment
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
@@ -28,12 +33,12 @@ RUN apt-get update -qq && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY services/ledger-service/Gemfile services/ledger-service/Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Copy application code
-COPY . .
+COPY services/ledger-service/ .
 
 
 # Final stage for app image
@@ -60,7 +65,6 @@ USER rails:rails
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
-# Start the server by default, this can be overwritten at runtime
-# Expose both ports - Railway will map to the PORT env var (8082)
-EXPOSE 3000 8082
+# HTTP (Puma) + gRPC (GRPC_PORT / railway.toml ledger-grpc internalPort)
+EXPOSE 3000 9090
 CMD ["./bin/rails", "server"]


### PR DESCRIPTION
### Problem
Railway cloned the whole `rails-core` repo, skipped `services/ledger-service/Dockerfile` (not at repo root), fell back to **Railpack**, and failed with *could not determine how to build*.

### Fix
- **Ledger Dockerfile** now matches **accounts/users**: build context is the **repository root**, with `COPY services/ledger-service/...`.
- **CI** `docker-builds` job builds ledger with `docker build -f services/ledger-service/Dockerfile .`
- **Root `.dockerignore`** trims context (`**/target/`, ledger `log/`/`tmp/`, etc.).

### What you set in Railway (no code secrets)
On the **ledger-service** (and optionally accounts/users for consistency), add variable:

```
RAILWAY_DOCKERFILE_PATH=services/ledger-service/Dockerfile
```

(accounts: `services/accounts-service/Dockerfile`, users: `services/users-service/Dockerfile`)

Choose **Dockerfile** builder. See **RAILWAY_DEPLOYMENT.md** for the full monorepo table and audit-service caveat.