### PR TITLE
ci: Railway deploy workflows match per-service test→deploy pattern

### DIFF
--- a/.github/workflows/deploy-railway-production.yml
+++ b/.github/workflows/deploy-railway-production.yml
@@ -1,13 +1,13 @@
-# Monorepo copy of per-service `services/*/.github/workflows/deploy-dev.yml` (same test → deploy shape).
+# Monorepo copy of per-service `services/*/.github/workflows/deploy-production.yml`.
 # Nested `.github/` under `services/` is not executed by GitHub Actions for this repository.
 #
-# Requires: RAILWAY_TOKEN on GitHub environment `development` (Railway project token for dev).
-name: Deploy to Railway Dev
+# Requires: RAILWAY_TOKEN on GitHub environment `production` (Railway project token for production).
+name: Test and Deploy to Production
 
 on:
   push:
     branches:
-      - develop
+      - main
 
 env:
   RUST_VERSION: stable
@@ -35,18 +35,18 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-accounts-service
+          shared-key: deploy-production-accounts-service
           workspaces: services/accounts-service
 
       - name: Run tests
         run: cargo test
 
   accounts-service-deploy:
-    name: accounts-service / Deploy to Railway Dev
+    name: accounts-service / Deploy to Railway Production
     runs-on: ubuntu-latest
     needs: accounts-service-test
     if: success()
-    environment: development
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,13 +56,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Production
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
             exit 1
           fi
           railway up --service accounts-service --detach
@@ -88,18 +88,19 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-users-service
+          shared-key: deploy-production-users-service
           workspaces: services/users-service
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         run: cargo test
 
   users-service-deploy:
-    name: users-service / Deploy to Railway Dev
+    name: users-service / Deploy to Railway Production
     runs-on: ubuntu-latest
     needs: users-service-test
     if: success()
-    environment: development
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -109,13 +110,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Production
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
             exit 1
           fi
           railway up --service users-service --detach
@@ -141,18 +142,18 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-audit-service
+          shared-key: deploy-production-audit-service
           workspaces: services/audit-service
 
       - name: Run tests
         run: cargo test
 
   audit-service-deploy:
-    name: audit-service / Deploy to Railway Dev
+    name: audit-service / Deploy to Railway Production
     runs-on: ubuntu-latest
     needs: audit-service-test
     if: success()
-    environment: development
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -162,13 +163,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Production
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
             exit 1
           fi
           railway up --service audit-service --detach
@@ -214,11 +215,11 @@ jobs:
         run: bundle exec rails test
 
   ledger-service-deploy:
-    name: ledger-service / Deploy to Railway Dev
+    name: ledger-service / Deploy to Railway Production
     runs-on: ubuntu-latest
     needs: ledger-service-test
     if: success()
-    environment: development
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -228,13 +229,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Production
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
             exit 1
           fi
           railway up --service ledger-service --detach

--- a/.github/workflows/deploy-railway-staging.yml
+++ b/.github/workflows/deploy-railway-staging.yml
@@ -1,13 +1,13 @@
-# Monorepo copy of per-service `services/*/.github/workflows/deploy-dev.yml` (same test → deploy shape).
+# Monorepo copy of per-service `services/*/.github/workflows/deploy-staging.yml`.
 # Nested `.github/` under `services/` is not executed by GitHub Actions for this repository.
 #
-# Requires: RAILWAY_TOKEN on GitHub environment `development` (Railway project token for dev).
-name: Deploy to Railway Dev
+# Requires: RAILWAY_TOKEN on GitHub environment `staging` (Railway project token for staging).
+name: Test and Deploy to Staging
 
 on:
   push:
     branches:
-      - develop
+      - staging
 
 env:
   RUST_VERSION: stable
@@ -35,18 +35,18 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-accounts-service
+          shared-key: deploy-staging-accounts-service
           workspaces: services/accounts-service
 
       - name: Run tests
         run: cargo test
 
   accounts-service-deploy:
-    name: accounts-service / Deploy to Railway Dev
+    name: accounts-service / Deploy to Railway Staging
     runs-on: ubuntu-latest
     needs: accounts-service-test
     if: success()
-    environment: development
+    environment: staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,13 +56,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Staging
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
             exit 1
           fi
           railway up --service accounts-service --detach
@@ -88,18 +88,19 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-users-service
+          shared-key: deploy-staging-users-service
           workspaces: services/users-service
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run tests
         run: cargo test
 
   users-service-deploy:
-    name: users-service / Deploy to Railway Dev
+    name: users-service / Deploy to Railway Staging
     runs-on: ubuntu-latest
     needs: users-service-test
     if: success()
-    environment: development
+    environment: staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -109,13 +110,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Staging
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
             exit 1
           fi
           railway up --service users-service --detach
@@ -141,18 +142,18 @@ jobs:
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: deploy-dev-audit-service
+          shared-key: deploy-staging-audit-service
           workspaces: services/audit-service
 
       - name: Run tests
         run: cargo test
 
   audit-service-deploy:
-    name: audit-service / Deploy to Railway Dev
+    name: audit-service / Deploy to Railway Staging
     runs-on: ubuntu-latest
     needs: audit-service-test
     if: success()
-    environment: development
+    environment: staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -162,13 +163,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Staging
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
             exit 1
           fi
           railway up --service audit-service --detach
@@ -214,11 +215,11 @@ jobs:
         run: bundle exec rails test
 
   ledger-service-deploy:
-    name: ledger-service / Deploy to Railway Dev
+    name: ledger-service / Deploy to Railway Staging
     runs-on: ubuntu-latest
     needs: ledger-service-test
     if: success()
-    environment: development
+    environment: staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -228,13 +229,13 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to Railway Dev
+      - name: Deploy to Railway Staging
         working-directory: ${{ github.workspace }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           if [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
             exit 1
           fi
           railway up --service ledger-service --detach

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ rails-core/
 │   ├── reset.sh              # compose down; --clear-env / --purge-neon (see README)
 │   ├── verify-layout.sh
 │   ├── health-check.sh
-│   ├── deploy-railway.sh     # optional Railway helper (Rust services)
+│   ├── deploy-railway.sh     # optional Railway helper (accounts, users, audit, ledger)
 │   └── lib/                  # neon_bootstrap.py, health_check.py, …
 │
 ├── infra/

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -14,6 +14,18 @@ This guide covers deploying the MVP services to Railway using **gRPC** for inter
 - Railway CLI installed + authenticated
 - Neon database connection strings ready
 
+## GitHub Actions (this monorepo)
+
+Railway deploy workflows must live under **`.github/workflows/`** at the **repository root** (GitHub does not run `services/*/.github/workflows/`).
+
+| Workflow file | Trigger | GitHub environment | Behaviour |
+|---------------|---------|--------------------|-----------|
+| `deploy-railway-dev.yml` | push to `develop` | `development` | Per service: **Run Tests** → **Deploy to Railway Dev** (`railway up --service … --detach` from repo root), same shape as the old per-repo `deploy-dev.yml` files under `services/`. |
+| `deploy-railway-staging.yml` | push to `staging` | `staging` | Same pattern for staging (`deploy-staging.yml` parity). |
+| `deploy-railway-production.yml` | push to `main` | `production` | Same pattern for production (`deploy-production.yml` parity). |
+
+YAML under `services/<name>/.github/workflows/` is a **reference** only; change behaviour by editing the **root** workflows above.
+
 ## Monorepo builds (avoid Railpack “could not determine how to build”)
 
 `rails-core` is a **monorepo**: Dockerfiles live under `services/<name>/`, but Railway often clones the **whole repo** with an **empty “Root Directory”**. In that mode Railpack runs at the repo root, skips nested Dockerfiles, and fails.

--- a/scripts/deploy-railway.sh
+++ b/scripts/deploy-railway.sh
@@ -2,20 +2,19 @@
 set -e
 
 # =============================================================================
-# Railway Deployment Helper (gRPC-only)
+# Railway Deployment Helper (monorepo)
 # =============================================================================
-# Deploys the MVP Rust services (accounts + users) to Railway.
+# Same pattern as root `.github/workflows/deploy-railway-*.yml`: from repo root,
+# `railway up --service <name> --detach` (required when the Railway project has
+# multiple services).
 #
 # Usage (from repository root):
 #   ./scripts/deploy-railway.sh [command]
 #
 # Commands:
-#   accounts    Deploy accounts service
-#   users       Deploy users service
-#   all         Deploy accounts then users
-#   status      Show project status
-#   logs        Tail logs for a service
-#   help        Show help
+#   accounts | users | audit | ledger   Deploy one service
+#   all                                  Deploy accounts, users, audit, ledger
+#   status | logs | help
 # =============================================================================
 
 RED='\033[0;31m'
@@ -43,11 +42,11 @@ require_railway() {
 }
 
 deploy_accounts() {
-  log_info "Deploying accounts service..."
-  cd "${RAILS_CORE}/services/accounts-service"
+  log_info "Deploying accounts-service..."
+  cd "${RAILS_CORE}"
   railway link
-  railway up --detach
-  log_success "Accounts deployment initiated"
+  railway up --service accounts-service --detach
+  log_success "accounts-service deployment initiated"
   echo ""
   echo "Set required variables in Railway Dashboard:"
   echo "  DATABASE_URL"
@@ -59,11 +58,11 @@ deploy_accounts() {
 }
 
 deploy_users() {
-  log_info "Deploying users service..."
-  cd "${RAILS_CORE}/services/users-service"
+  log_info "Deploying users-service..."
+  cd "${RAILS_CORE}"
   railway link
-  railway up --detach
-  log_success "Users deployment initiated"
+  railway up --service users-service --detach
+  log_success "users-service deployment initiated"
   echo ""
   echo "Set required variables in Railway Dashboard:"
   echo "  DATABASE_URL"
@@ -72,6 +71,34 @@ deploy_users() {
   echo "  ACCOUNTS_GRPC_URL"
   echo "  API_KEY_HASH_SECRET"
   echo "  INTERNAL_SERVICE_TOKEN_ALLOWLIST (recommended)"
+}
+
+deploy_audit() {
+  log_info "Deploying audit-service..."
+  cd "${RAILS_CORE}"
+  railway link
+  railway up --service audit-service --detach
+  log_success "audit-service deployment initiated"
+  echo ""
+  echo "Set required variables in Railway Dashboard:"
+  echo "  DATABASE_URL"
+  echo "  SERVER_ADDR"
+  echo "  GRPC_PORT"
+  echo "  RUST_LOG"
+}
+
+deploy_ledger() {
+  log_info "Deploying ledger-service..."
+  cd "${RAILS_CORE}"
+  railway link
+  railway up --service ledger-service --detach
+  log_success "ledger-service deployment initiated"
+  echo ""
+  echo "Set required variables in Railway Dashboard:"
+  echo "  DATABASE_URL"
+  echo "  GRPC_PORT"
+  echo "  RAILS_ENV"
+  echo "  LOG_LEVEL"
 }
 
 show_status() {
@@ -92,12 +119,11 @@ show_help() {
 Usage: ./deploy-railway.sh [command]
 
 Commands:
-  accounts    Deploy accounts service
-  users       Deploy users service
-  all         Deploy accounts then users
-  status      Show project status
-  logs        Tail logs for a service
-  help        Show help
+  accounts | users | audit | ledger   Deploy one service
+  all                                Deploy all four (in order)
+  status                             railway status
+  logs                               railway logs (prompts for service name)
+  help                               This message
 EOF
 }
 
@@ -106,10 +132,19 @@ require_railway
 case "${1:-help}" in
   accounts) deploy_accounts ;;
   users) deploy_users ;;
-  all) deploy_accounts; echo ""; deploy_users ;;
+  audit) deploy_audit ;;
+  ledger) deploy_ledger ;;
+  all)
+    deploy_accounts
+    echo ""
+    deploy_users
+    echo ""
+    deploy_audit
+    echo ""
+    deploy_ledger
+    ;;
   status) show_status ;;
   logs) show_logs ;;
   help|--help|-h) show_help ;;
   *) log_error "Unknown command: ${1}"; show_help; exit 1 ;;
 esac
-


### PR DESCRIPTION
### Summary
Mirrors the **accounts-service**, **users-service**, and **ledger-service** (plus **audit-service**) nested `deploy-*.yml` layout at the **monorepo root**, since GitHub only runs `.github/workflows/` at the repo root.

### Changes
- **`deploy-railway-dev.yml`**: one **Run Tests** job + one **Deploy to Railway Dev** job per service, `needs: …-test`, same step names and `RAILWAY_TOKEN` error text as the old per-repo workflows; deploy runs `railway up --service <name> --detach` from `${{ github.workspace }}`.
- **`deploy-railway-staging.yml`** / **`deploy-railway-production.yml`**: same pattern for `staging` / `main` (users rust-cache `save-if` matches nested staging/production).
- **`scripts/deploy-railway.sh`**: deploy from repo root with `--service` for accounts, users, audit, ledger; `all` runs all four.
- **Docs / README**: table of root workflows vs nested reference-only YAML.

### Note
Nested `services/*/.github/workflows/` files are unchanged and remain **reference-only** for humans; edit **root** workflows for CI behaviour.