### PR TITLE
fix(ci): restore Railway deploy workflows and audit Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,14 +240,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [users-service, accounts-service, ledger-service]
+        service: [users-service, accounts-service, audit-service, ledger-service]
     steps:
       - uses: actions/checkout@v4
       - name: Build image
         run: |
           if [ "${{ matrix.service }}" = "ledger-service" ]; then
             docker build -f "services/ledger-service/Dockerfile" .
+          elif [ "${{ matrix.service }}" = "audit-service" ]; then
+            docker build -f "services/audit-service/Dockerfile" .
           else
-            # Rust services use path `../audit-service` and build.rs `../../proto`; context must be repo root.
+            # Rust services use sibling `services/audit-service` and build.rs `../../proto`; context must be repo root.
             docker build -f "services/${{ matrix.service }}/Dockerfile" .
           fi

--- a/.github/workflows/deploy-railway-dev.yml
+++ b/.github/workflows/deploy-railway-dev.yml
@@ -1,0 +1,240 @@
+# Monorepo copy of per-service `services/*/.github/workflows/deploy-dev.yml` (same test → deploy shape).
+# Nested `.github/` under `services/` is not executed by GitHub Actions for this repository.
+#
+# Requires: RAILWAY_TOKEN on GitHub environment `development` (Railway project token for dev).
+name: Deploy to Railway Dev
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  RUST_VERSION: stable
+  RUBY_VERSION: "3.3.0"
+
+jobs:
+  accounts-service-test:
+    name: accounts-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/accounts-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-dev-accounts-service
+          workspaces: services/accounts-service
+
+      - name: Run tests
+        run: cargo test
+
+  accounts-service-deploy:
+    name: accounts-service / Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: accounts-service-test
+    if: success()
+    environment: development
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+
+  users-service-test:
+    name: users-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/users-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-dev-users-service
+          workspaces: services/users-service
+
+      - name: Run tests
+        run: cargo test
+
+  users-service-deploy:
+    name: users-service / Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: users-service-test
+    if: success()
+    environment: development
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service users-service --detach
+
+  audit-service-test:
+    name: audit-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/audit-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-dev-audit-service
+          workspaces: services/audit-service
+
+      - name: Run tests
+        run: cargo test
+
+  audit-service-deploy:
+    name: audit-service / Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: audit-service-test
+    if: success()
+    environment: development
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service audit-service --detach
+
+  ledger-service-test:
+    name: ledger-service / Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    defaults:
+      run:
+        working-directory: services/ledger-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: services/ledger-service
+
+      - name: Setup test database
+        run: bundle exec rails db:create db:schema:load
+
+      - name: Run tests
+        run: bundle exec rails test
+
+  ledger-service-deploy:
+    name: ledger-service / Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: ledger-service-test
+    if: success()
+    environment: development
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service ledger-service --detach

--- a/.github/workflows/deploy-railway-production.yml
+++ b/.github/workflows/deploy-railway-production.yml
@@ -1,0 +1,241 @@
+# Monorepo copy of per-service `services/*/.github/workflows/deploy-production.yml`.
+# Nested `.github/` under `services/` is not executed by GitHub Actions for this repository.
+#
+# Requires: RAILWAY_TOKEN on GitHub environment `production` (Railway project token for production).
+name: Test and Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  RUST_VERSION: stable
+  RUBY_VERSION: "3.3.0"
+
+jobs:
+  accounts-service-test:
+    name: accounts-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/accounts-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-production-accounts-service
+          workspaces: services/accounts-service
+
+      - name: Run tests
+        run: cargo test
+
+  accounts-service-deploy:
+    name: accounts-service / Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: accounts-service-test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+
+  users-service-test:
+    name: users-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/users-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-production-users-service
+          workspaces: services/users-service
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run tests
+        run: cargo test
+
+  users-service-deploy:
+    name: users-service / Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: users-service-test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service users-service --detach
+
+  audit-service-test:
+    name: audit-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/audit-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-production-audit-service
+          workspaces: services/audit-service
+
+      - name: Run tests
+        run: cargo test
+
+  audit-service-deploy:
+    name: audit-service / Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: audit-service-test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service audit-service --detach
+
+  ledger-service-test:
+    name: ledger-service / Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    defaults:
+      run:
+        working-directory: services/ledger-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: services/ledger-service
+
+      - name: Setup test database
+        run: bundle exec rails db:create db:schema:load
+
+      - name: Run tests
+        run: bundle exec rails test
+
+  ledger-service-deploy:
+    name: ledger-service / Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: ledger-service-test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service ledger-service --detach

--- a/.github/workflows/deploy-railway-staging.yml
+++ b/.github/workflows/deploy-railway-staging.yml
@@ -1,0 +1,241 @@
+# Monorepo copy of per-service `services/*/.github/workflows/deploy-staging.yml`.
+# Nested `.github/` under `services/` is not executed by GitHub Actions for this repository.
+#
+# Requires: RAILWAY_TOKEN on GitHub environment `staging` (Railway project token for staging).
+name: Test and Deploy to Staging
+
+on:
+  push:
+    branches:
+      - staging
+
+env:
+  RUST_VERSION: stable
+  RUBY_VERSION: "3.3.0"
+
+jobs:
+  accounts-service-test:
+    name: accounts-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/accounts-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-staging-accounts-service
+          workspaces: services/accounts-service
+
+      - name: Run tests
+        run: cargo test
+
+  accounts-service-deploy:
+    name: accounts-service / Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: accounts-service-test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+
+  users-service-test:
+    name: users-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/users-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-staging-users-service
+          workspaces: services/users-service
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run tests
+        run: cargo test
+
+  users-service-deploy:
+    name: users-service / Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: users-service-test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service users-service --detach
+
+  audit-service-test:
+    name: audit-service / Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/audit-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-staging-audit-service
+          workspaces: services/audit-service
+
+      - name: Run tests
+        run: cargo test
+
+  audit-service-deploy:
+    name: audit-service / Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: audit-service-test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service audit-service --detach
+
+  ledger-service-test:
+    name: ledger-service / Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    defaults:
+      run:
+        working-directory: services/ledger-service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+          working-directory: services/ledger-service
+
+      - name: Setup test database
+        run: bundle exec rails db:create db:schema:load
+
+      - name: Run tests
+        run: bundle exec rails test
+
+  ledger-service-deploy:
+    name: ledger-service / Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: ledger-service-test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        working-directory: ${{ github.workspace }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service ledger-service --detach

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ rails-core/
 │   ├── reset.sh              # compose down; --clear-env / --purge-neon (see README)
 │   ├── verify-layout.sh
 │   ├── health-check.sh
+│   ├── deploy-railway.sh     # optional Railway helper (accounts, users, audit, ledger)
 │   └── lib/                  # neon_bootstrap.py, health_check.py, …
 │
 ├── infra/
@@ -188,7 +189,8 @@ rails-core/
 │   ├── architecture.md
 │   ├── audit-trail-architecture.md
 │   ├── quickstart.md
-│   └── index.html
+│   ├── index.html
+│   └── RAILWAY_DEPLOYMENT.md
 │
 ├── docker-compose.yml
 ├── Makefile
@@ -204,6 +206,7 @@ rails-core/
 - [docs/quickstart.md](docs/quickstart.md) — clone → env → `make dev`  
 - [docs/audit-trail-architecture.md](docs/audit-trail-architecture.md) — audit-service, gRPC ingest, dedicated database  
 - [services/audit-service/README.md](services/audit-service/README.md) — runbook for the audit microservice  
+- [docs/RAILWAY_DEPLOYMENT.md](docs/RAILWAY_DEPLOYMENT.md) — optional Railway helper for Rust services  
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to change code and open a PR  
 
 ## Service manifest

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -1,0 +1,99 @@
+# Railway Deployment Guide (gRPC-only)
+
+This guide covers deploying the MVP services to Railway using **gRPC** for inter-service communication.
+
+## Architecture Overview
+
+- **users-service (Rust)**: Public HTTP API for user/auth flows. Calls accounts via gRPC.
+- **accounts-service (Rust)**: HTTP API + gRPC server for account operations.
+- **ledger (Rails)**: gRPC server for ledger posting (optional, depending on which flows you run).
+- **PostgreSQL (Neon)**: Shared database.
+
+## Prerequisites
+
+- Railway CLI installed + authenticated
+- Neon database connection strings ready
+
+## GitHub Actions (this monorepo)
+
+Railway deploy workflows must live under **`.github/workflows/`** at the **repository root** (GitHub does not run `services/*/.github/workflows/`).
+
+| Workflow file | Trigger | GitHub environment | Behaviour |
+|---------------|---------|--------------------|-----------|
+| `deploy-railway-dev.yml` | push to `develop` | `development` | Per service: **Run Tests** → **Deploy to Railway Dev** (`railway up --service … --detach` from repo root), same shape as the old per-repo `deploy-dev.yml` files under `services/`. |
+| `deploy-railway-staging.yml` | push to `staging` | `staging` | Same pattern for staging (`deploy-staging.yml` parity). |
+| `deploy-railway-production.yml` | push to `main` | `production` | Same pattern for production (`deploy-production.yml` parity). |
+
+YAML under `services/<name>/.github/workflows/` is a **reference** only; change behaviour by editing the **root** workflows above.
+
+## Monorepo builds (avoid Railpack “could not determine how to build”)
+
+`rails-core` is a **monorepo**: Dockerfiles live under `services/<name>/`, but Railway often clones the **whole repo** with an **empty “Root Directory”**. In that mode Railpack runs at the repo root, skips nested Dockerfiles, and fails.
+
+Pick **one** approach per service:
+
+### A) Service variable `RAILWAY_DOCKERFILE_PATH` (full repo checkout)
+
+Set on each Railway service (Variables), paths relative to repo root:
+
+| Service | `RAILWAY_DOCKERFILE_PATH` |
+|---------|---------------------------|
+| accounts-service | `services/accounts-service/Dockerfile` |
+| users-service | `services/users-service/Dockerfile` |
+| ledger-service | `services/ledger-service/Dockerfile` |
+| audit-service | `services/audit-service/Dockerfile` |
+
+Then set **Builder** to **Dockerfile** (disable Railpack auto-detect if the UI offers it). Build context remains the **repository root**, which matches these Dockerfiles.
+
+**audit-service** uses the same **repo-root** Docker build as the other Rust services (`docker build -f services/audit-service/Dockerfile .` from the monorepo root). Set **Root Directory** empty (repo root) and point **Config as code** at `/services/audit-service/railway.toml` if needed.
+
+### B) Root directory per service (isolated monorepo)
+
+In Railway → service → **Settings → Root Directory**, set e.g. `services/<service>`. Railway then uses that folder as the build context; only use this if the service’s Dockerfile is written for that **narrow** context. The **ledger** Dockerfile in this repo expects the **monorepo root**—use **A** for ledger unless you maintain a separate crate-local Dockerfile.
+
+Official reference: [Deploying an isolated monorepo](https://docs.railway.app/deployments/monorepo), [Dockerfiles](https://docs.railway.app/builds/dockerfiles).
+
+## Deploy
+
+### 1) Deploy Accounts Service
+
+From `services/accounts-service`:
+
+- Deploy service
+- Set variables:
+  - `DATABASE_URL`
+  - `PORT`
+  - `GRPC_PORT`
+  - `LEDGER_GRPC_URL` (ledger **gRPC** URL, e.g. `http://<ledger-grpc host>.railway.internal:9090` on private networking—not the Rails HTTP URL)
+  - `HOST`
+  - `RUST_LOG`
+
+### 2) Deploy Users Service
+
+From `services/users-service`:
+
+- Deploy service
+- Set variables:
+  - `DATABASE_URL`
+  - `SERVER_ADDR` (or `HOST` + `PORT` depending on your setup)
+  - `RUST_LOG`
+  - `ACCOUNTS_GRPC_URL` (point to accounts-service internal host + gRPC port)
+  - `API_KEY_HASH_SECRET` (required for production)
+  - `INTERNAL_SERVICE_TOKEN_ALLOWLIST` (recommended hardening)
+
+### 3) (Optional) Deploy Ledger Service
+
+From `services/ledger-service`:
+
+- Deploy service
+- Set variables:
+  - `DATABASE_URL`
+  - `GRPC_PORT` — defaults to **9090** in-app, matching **`ledger-grpc` `internalPort`** in `railway.toml`. Set only if you change that port.
+  - `RAILS_ENV`
+  - `LOG_LEVEL`
+
+## Verification
+
+- Users service boots and can reach Accounts gRPC (`ACCOUNTS_GRPC_URL`).
+- Accounts service boots and logs gRPC startup on `GRPC_PORT`.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
   <ul>
     <li><a href="architecture.md">architecture.md</a> — system diagram and boundaries</li>
     <li><a href="quickstart.md">quickstart.md</a> — clone, env, <code>make dev</code></li>
+    <li><a href="RAILWAY_DEPLOYMENT.md">RAILWAY_DEPLOYMENT.md</a> — optional Railway notes</li>
   </ul>
   <p>Public gateway (with compose running): <a href="http://localhost:8080/">http://localhost:8080/</a></p>
 </body>

--- a/scripts/deploy-railway.sh
+++ b/scripts/deploy-railway.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+set -e
+
+# =============================================================================
+# Railway Deployment Helper (monorepo)
+# =============================================================================
+# Same pattern as root `.github/workflows/deploy-railway-*.yml`: from repo root,
+# `railway up --service <name> --detach` (required when the Railway project has
+# multiple services).
+#
+# Usage (from repository root):
+#   ./scripts/deploy-railway.sh [command]
+#
+# Commands:
+#   accounts | users | audit | ledger   Deploy one service
+#   all                                  Deploy accounts, users, audit, ledger
+#   status | logs | help
+# =============================================================================
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RAILS_CORE="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+require_railway() {
+  if ! command -v railway >/dev/null 2>&1; then
+    log_error "Railway CLI not found. Install with: npm install -g @railway/cli"
+    exit 1
+  fi
+  if ! railway whoami >/dev/null 2>&1; then
+    log_error "Not logged in to Railway. Run: railway login"
+    exit 1
+  fi
+}
+
+deploy_accounts() {
+  log_info "Deploying accounts-service..."
+  cd "${RAILS_CORE}"
+  railway link
+  railway up --service accounts-service --detach
+  log_success "accounts-service deployment initiated"
+  echo ""
+  echo "Set required variables in Railway Dashboard:"
+  echo "  DATABASE_URL"
+  echo "  PORT"
+  echo "  GRPC_PORT"
+  echo "  LEDGER_GRPC_URL"
+  echo "  HOST"
+  echo "  RUST_LOG"
+}
+
+deploy_users() {
+  log_info "Deploying users-service..."
+  cd "${RAILS_CORE}"
+  railway link
+  railway up --service users-service --detach
+  log_success "users-service deployment initiated"
+  echo ""
+  echo "Set required variables in Railway Dashboard:"
+  echo "  DATABASE_URL"
+  echo "  SERVER_ADDR (or HOST + PORT depending on your setup)"
+  echo "  RUST_LOG"
+  echo "  ACCOUNTS_GRPC_URL"
+  echo "  API_KEY_HASH_SECRET"
+  echo "  INTERNAL_SERVICE_TOKEN_ALLOWLIST (recommended)"
+}
+
+deploy_audit() {
+  log_info "Deploying audit-service..."
+  cd "${RAILS_CORE}"
+  railway link
+  railway up --service audit-service --detach
+  log_success "audit-service deployment initiated"
+  echo ""
+  echo "Set required variables in Railway Dashboard:"
+  echo "  DATABASE_URL"
+  echo "  SERVER_ADDR"
+  echo "  GRPC_PORT"
+  echo "  RUST_LOG"
+}
+
+deploy_ledger() {
+  log_info "Deploying ledger-service..."
+  cd "${RAILS_CORE}"
+  railway link
+  railway up --service ledger-service --detach
+  log_success "ledger-service deployment initiated"
+  echo ""
+  echo "Set required variables in Railway Dashboard:"
+  echo "  DATABASE_URL"
+  echo "  GRPC_PORT"
+  echo "  RAILS_ENV"
+  echo "  LOG_LEVEL"
+}
+
+show_status() {
+  railway status
+}
+
+show_logs() {
+  read -p "Enter Railway service name (e.g. users-service): " service_name
+  if [ -z "$service_name" ]; then
+    log_error "No service name provided"
+    exit 1
+  fi
+  railway logs --service "$service_name"
+}
+
+show_help() {
+  cat <<'EOF'
+Usage: ./deploy-railway.sh [command]
+
+Commands:
+  accounts | users | audit | ledger   Deploy one service
+  all                                Deploy all four (in order)
+  status                             railway status
+  logs                               railway logs (prompts for service name)
+  help                               This message
+EOF
+}
+
+require_railway
+
+case "${1:-help}" in
+  accounts) deploy_accounts ;;
+  users) deploy_users ;;
+  audit) deploy_audit ;;
+  ledger) deploy_ledger ;;
+  all)
+    deploy_accounts
+    echo ""
+    deploy_users
+    echo ""
+    deploy_audit
+    echo ""
+    deploy_ledger
+    ;;
+  status) show_status ;;
+  logs) show_logs ;;
+  help|--help|-h) show_help ;;
+  *) log_error "Unknown command: ${1}"; show_help; exit 1 ;;
+esac

--- a/services/accounts-service/.github/workflows/deploy-dev.yml
+++ b/services/accounts-service/.github/workflows/deploy-dev.yml
@@ -1,0 +1,63 @@
+name: Deploy to Railway Dev
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  RUST_VERSION: 'stable'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+
+      - name: Run tests
+        run: cargo test
+
+  # Deploy uses only the project token (RAILWAY_TOKEN). No account token or railway link needed.
+  # Get RAILWAY_TOKEN: Railway project → Settings → Tokens → create token for the "dev" environment.
+  # Project tokens are scoped to one project+environment; the CLI deploys to that target. Use --service when the project has multiple services.
+  deploy:
+    name: Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: test
+    if: success() # Only deploy if tests pass
+    environment: development
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/accounts-service/.github/workflows/deploy-production.yml
+++ b/services/accounts-service/.github/workflows/deploy-production.yml
@@ -1,0 +1,61 @@
+# On push to main: run tests, then deploy to Railway production.
+# Uses RAILWAY_TOKEN from the GitHub "production" environment.
+# Add RAILWAY_TOKEN in Settings → Environments → production → Environment secrets (Railway project token for production).
+name: Test and Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  RUST_VERSION: 'stable'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+
+      - name: Run tests
+        run: cargo test
+
+  deploy:
+    name: Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/accounts-service/.github/workflows/deploy-staging.yml
+++ b/services/accounts-service/.github/workflows/deploy-staging.yml
@@ -1,0 +1,60 @@
+# On push to staging: run tests, then deploy to Railway staging.
+# Uses project token for staging (RAILWAY_TOKEN in the staging environment).
+name: Test and Deploy to Staging
+
+on:
+  push:
+    branches:
+      - staging
+
+env:
+  RUST_VERSION: 'stable'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+
+      - name: Run tests
+        run: cargo test
+
+  deploy:
+    name: Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service accounts-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/accounts-service/railway.toml
+++ b/services/accounts-service/railway.toml
@@ -1,0 +1,18 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3
+
+[[services]]
+name = "accounts-service"
+internalPort = 8081
+
+[[services]]
+name = "accounts-grpc"
+internalPort = 9090
+protocol = "grpc"

--- a/services/audit-service/Dockerfile
+++ b/services/audit-service/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+#
+# Build context: **repository root** (`rails-core`), same contract as
+# `services/accounts-service/Dockerfile` and CI `docker-builds`.
+#
+#   docker build -f services/audit-service/Dockerfile .
+
+FROM rust:1.92-slim-bookworm AS builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config=1.8.1-1 \
+    libssl-dev=3.0.19-1~deb12u2 \
+    protobuf-compiler=3.21.12-3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY proto /build/proto
+COPY services/audit-service /build/services/audit-service
+
+WORKDIR /build/services/audit-service
+
+RUN cargo build --locked --release
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates=20230311+deb12u1 \
+    libssl3=3.0.19-1~deb12u2 \
+    curl=7.88.1-10+deb12u14 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /build/services/audit-service/target/release/audit_service /usr/local/bin/audit_service
+
+ENV SERVER_ADDR=0.0.0.0:8080
+
+EXPOSE 8080 50054
+
+CMD ["/usr/local/bin/audit_service"]

--- a/services/audit-service/railway.toml
+++ b/services/audit-service/railway.toml
@@ -1,0 +1,18 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3
+
+[[services]]
+name = "audit-service"
+internalPort = 8080
+
+[[services]]
+name = "audit-grpc"
+internalPort = 50054
+protocol = "grpc"

--- a/services/ledger-service/.github/workflows/deploy-dev.yml
+++ b/services/ledger-service/.github/workflows/deploy-dev.yml
@@ -1,0 +1,75 @@
+name: Deploy to Railway Dev
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  RUBY_VERSION: '3.3.0'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Setup test database
+        run: bundle exec rails db:create db:schema:load
+      - name: Run tests
+        run: bundle exec rails test
+
+  # Deploy uses only the project token (RAILWAY_TOKEN). No account token or railway link needed.
+  # Get RAILWAY_TOKEN: Railway project → Settings → Tokens → create token for the "dev" environment.
+  # Project tokens are scoped to one project+environment; the CLI deploys to that target. Use --service when the project has multiple services.
+  deploy:
+    name: Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: test
+    if: success() # Only deploy if tests pass
+    environment: development
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service ledger-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/ledger-service/.github/workflows/deploy-production.yml
+++ b/services/ledger-service/.github/workflows/deploy-production.yml
@@ -1,0 +1,73 @@
+# On push to main: run tests, then deploy to Railway production.
+# Uses RAILWAY_TOKEN from the GitHub "production" environment.
+# Add RAILWAY_TOKEN in Settings → Environments → production → Environment secrets (Railway project token for production).
+name: Test and Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  RUBY_VERSION: '3.3.0'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Setup test database
+        run: bundle exec rails db:create db:schema:load
+      - name: Run tests
+        run: bundle exec rails test
+
+  deploy:
+    name: Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service ledger-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/ledger-service/.github/workflows/deploy-staging.yml
+++ b/services/ledger-service/.github/workflows/deploy-staging.yml
@@ -1,0 +1,72 @@
+# On push to staging: run tests, then deploy to Railway staging.
+# Uses project token for staging (RAILWAY_TOKEN in the staging environment).
+name: Test and Deploy to Staging
+
+on:
+  push:
+    branches:
+      - staging
+
+env:
+  RUBY_VERSION: '3.3.0'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ledger_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Setup test database
+        run: bundle exec rails db:create db:schema:load
+      - name: Run tests
+        run: bundle exec rails test
+
+  deploy:
+    name: Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service ledger-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/ledger-service/railway.toml
+++ b/services/ledger-service/railway.toml
@@ -1,0 +1,18 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/up"
+healthcheckTimeout = 60
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3
+
+[[services]]
+name = "ledger-service"
+internalPort = 3000
+
+[[services]]
+name = "ledger-grpc"
+internalPort = 9090
+protocol = "grpc"

--- a/services/users-service/.github/workflows/deploy-dev.yml
+++ b/services/users-service/.github/workflows/deploy-dev.yml
@@ -1,0 +1,64 @@
+name: Deploy to Railway Dev
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  RUST_VERSION: 'stable'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run tests
+        run: cargo test
+
+  # Deploy uses only the project token (RAILWAY_TOKEN). No account token or railway link needed.
+  # Get RAILWAY_TOKEN: Railway project → Settings → Tokens → create token for the "dev" environment.
+  # Project tokens are scoped to one project+environment; the CLI deploys to that target. Use --service when the project has multiple services.
+  deploy:
+    name: Deploy to Railway Dev
+    runs-on: ubuntu-latest
+    needs: test
+    if: success() # Only deploy if tests pass
+    environment: development
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Dev
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set. Add it in repo Settings → Secrets and variables → Actions. Create token in Railway project → Settings → Tokens (dev environment)."
+            exit 1
+          fi
+          railway up --service users-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/users-service/.github/workflows/deploy-production.yml
+++ b/services/users-service/.github/workflows/deploy-production.yml
@@ -1,0 +1,62 @@
+# On push to main: run tests, then deploy to Railway production.
+# Uses RAILWAY_TOKEN from the GitHub "production" environment.
+# Add RAILWAY_TOKEN in Settings → Environments → production → Environment secrets (Railway project token for production).
+name: Test and Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  RUST_VERSION: 'stable'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run tests
+        run: cargo test
+
+  deploy:
+    name: Deploy to Railway Production
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Production
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for production. Add it in Settings → Environments → production → Environment secrets (Railway project token for production)."
+            exit 1
+          fi
+          railway up --service users-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/users-service/.github/workflows/deploy-staging.yml
+++ b/services/users-service/.github/workflows/deploy-staging.yml
@@ -1,0 +1,61 @@
+# On push to staging: run tests, then deploy to Railway staging.
+# Uses project token for staging (RAILWAY_TOKEN in the staging environment).
+name: Test and Deploy to Staging
+
+on:
+  push:
+    branches:
+      - staging
+
+env:
+  RUST_VERSION: 'stable'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run tests
+        run: cargo test
+
+  deploy:
+    name: Deploy to Railway Staging
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway Staging
+        run: |
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN not set for staging. Add it in Settings → Environments → staging → Environment secrets (project token for staging environment)."
+            exit 1
+          fi
+          railway up --service users-service --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/services/users-service/railway.toml
+++ b/services/users-service/railway.toml
@@ -1,0 +1,13 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3
+
+[[services]]
+name = "users-service"
+internalPort = 8080


### PR DESCRIPTION
## What broke
PR #36 removed Railway automation from the monorepo; pushes to `develop` no longer ran tests plus `railway up`, and **audit-service** had no repo-root Dockerfile for Railway to build.

## What this does
- Restores root `deploy-railway-{dev,staging,production}.yml`, `scripts/deploy-railway.sh`, `docs/RAILWAY_DEPLOYMENT.md`, per-service `railway.toml`, and nested deploy YAML as **reference** copies (same as pre-#36 / #35).
- Adds `services/audit-service/Dockerfile` with **repository root** build context (aligned with accounts/users) plus `services/audit-service/railway.toml`.
- Extends CI `docker-builds` to compile the audit image so regressions surface on PRs.

## Railway
After merge, a push to `develop` triggers **Deploy to Railway Dev** again (requires `RAILWAY_TOKEN` on the GitHub `development` environment). Set each Railway service `RAILWAY_DOCKERFILE_PATH` as documented for repo-root Dockerfiles.