### PR TITLE
RAI-16: fail fast on invalid ledger startup config

### DIFF
--- a/services/accounts-service/src/config/settings.rs
+++ b/services/accounts-service/src/config/settings.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use tonic::transport::Endpoint;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {
@@ -16,6 +17,24 @@ pub struct Settings {
 }
 
 impl Settings {
+    fn validate_grpc_url(
+        env_key: &str,
+        value: String,
+    ) -> Result<String, config::ConfigError> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(config::ConfigError::Message(format!(
+                "{} must be a non-empty URI",
+                env_key
+            )));
+        }
+
+        Endpoint::from_shared(trimmed.to_string()).map_err(|e| {
+            config::ConfigError::Message(format!("invalid {}: {}", env_key, e))
+        })?;
+        Ok(trimmed.to_string())
+    }
+
     pub fn from_env() -> Result<Self, config::ConfigError> {
         const DATABASE_URL_ENV: &str = "DATABASE_URL";
         const PORT_ENV: &str = "PORT";
@@ -41,8 +60,10 @@ impl Settings {
             .parse()
             .unwrap_or(9090);
 
-        let ledger_grpc_url = std::env::var(LEDGER_GRPC_URL_ENV)
-            .unwrap_or_else(|_| "http://127.0.0.1:50053".to_string());
+        let ledger_grpc_url = match std::env::var(LEDGER_GRPC_URL_ENV) {
+            Ok(value) => Self::validate_grpc_url(LEDGER_GRPC_URL_ENV, value)?,
+            Err(_) => "http://127.0.0.1:50053".to_string(),
+        };
 
         let users_grpc_url = std::env::var(USERS_GRPC_URL_ENV)
             .unwrap_or_else(|_| "http://127.0.0.1:50051".to_string());
@@ -70,5 +91,70 @@ impl Settings {
             sentry_dsn,
             environment,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Settings;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const DATABASE_URL_ENV: &str = "DATABASE_URL";
+    const LEDGER_GRPC_URL_ENV: &str = "LEDGER_GRPC_URL";
+    const USERS_GRPC_URL_ENV: &str = "USERS_GRPC_URL";
+    const AUDIT_GRPC_URL_ENV: &str = "AUDIT_GRPC_URL";
+
+    fn set_required_env() {
+        std::env::set_var(
+            DATABASE_URL_ENV,
+            "postgres://postgres:postgres@localhost:5432/postgres",
+        );
+        std::env::set_var(USERS_GRPC_URL_ENV, "http://127.0.0.1:50051");
+        std::env::set_var(AUDIT_GRPC_URL_ENV, "http://127.0.0.1:50054");
+    }
+
+    fn clear_required_env() {
+        std::env::remove_var(DATABASE_URL_ENV);
+        std::env::remove_var(LEDGER_GRPC_URL_ENV);
+        std::env::remove_var(USERS_GRPC_URL_ENV);
+        std::env::remove_var(AUDIT_GRPC_URL_ENV);
+    }
+
+    #[test]
+    fn from_env_accepts_valid_ledger_grpc_url() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_required_env();
+        std::env::set_var(LEDGER_GRPC_URL_ENV, "http://ledger-service:50053");
+
+        let settings = Settings::from_env().expect("valid settings");
+        assert_eq!(settings.ledger_grpc_url, "http://ledger-service:50053");
+
+        clear_required_env();
+    }
+
+    #[test]
+    fn from_env_rejects_empty_ledger_grpc_url() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_required_env();
+        std::env::set_var(LEDGER_GRPC_URL_ENV, "   ");
+
+        let err = Settings::from_env().expect_err("empty URL should fail");
+        assert!(format!("{}", err).contains("LEDGER_GRPC_URL"));
+
+        clear_required_env();
+    }
+
+    #[test]
+    fn from_env_rejects_malformed_ledger_grpc_url() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        set_required_env();
+        std::env::set_var(LEDGER_GRPC_URL_ENV, "http://[::1");
+
+        let err = Settings::from_env().expect_err("malformed URL should fail");
+        assert!(format!("{}", err).contains("invalid LEDGER_GRPC_URL"));
+
+        clear_required_env();
     }
 }

--- a/services/accounts-service/src/lib.rs
+++ b/services/accounts-service/src/lib.rs
@@ -17,6 +17,7 @@ pub mod utils;
 use axum::serve;
 use sqlx::postgres::PgPoolOptions;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::prelude::*;
@@ -29,6 +30,7 @@ use grpc::accounts::AccountsGrpcService;
 use grpc::proto::accounts_service_server::AccountsServiceServer;
 use sqlx::PgPool;
 use tonic::transport::Server;
+use tonic::transport::Endpoint;
 
 pub(crate) fn resolve_migrate_run_result(
     result: Result<(), sqlx::migrate::MigrateError>,
@@ -54,6 +56,20 @@ pub(crate) async fn run_accounts_migrations(pool: &PgPool) -> Result<(), Box<dyn
     migrator.set_ignore_missing(true);
     resolve_migrate_run_result(migrator.run(pool).await)?;
     Ok(())
+}
+
+pub(crate) async fn probe_ledger_connectivity(
+    endpoint: &str,
+    timeout: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ep = Endpoint::from_shared(endpoint.to_string())
+        .map_err(|e| anyhow::anyhow!("invalid LEDGER_GRPC_URL: {}", e))?;
+    ep.connect_timeout(timeout)
+        .timeout(timeout)
+        .connect()
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("ledger startup connectivity probe failed: {}", e).into())
 }
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -101,6 +117,11 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     info!("Database migrations completed");
 
     let ledger_grpc = LedgerGrpc::new(settings.ledger_grpc_url.clone());
+    probe_ledger_connectivity(ledger_grpc.endpoint(), Duration::from_secs(2)).await?;
+    info!(
+        "Ledger gRPC startup connectivity probe succeeded at {}",
+        ledger_grpc.endpoint()
+    );
 
     let users_grpc = users_grpc::UsersGrpc::connect_lazy(&settings.users_grpc_url)?;
     info!(
@@ -221,5 +242,27 @@ mod run_accounts_migrations_smoke {
         run_accounts_migrations(&pool)
             .await
             .expect("second migration run should succeed");
+    }
+}
+
+#[cfg(test)]
+mod ledger_probe_tests {
+    use super::probe_ledger_connectivity;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn ledger_probe_rejects_invalid_uri() {
+        let err = probe_ledger_connectivity("http://[::1", Duration::from_millis(50))
+            .await
+            .expect_err("invalid URI should fail");
+        assert!(format!("{}", err).contains("invalid LEDGER_GRPC_URL"));
+    }
+
+    #[tokio::test]
+    async fn ledger_probe_fails_for_unreachable_target() {
+        let err = probe_ledger_connectivity("http://127.0.0.1:9", Duration::from_millis(50))
+            .await
+            .expect_err("unreachable endpoint should fail");
+        assert!(format!("{}", err).contains("ledger startup connectivity probe failed"));
     }
 }


### PR DESCRIPTION
## Summary
- validate `LEDGER_GRPC_URL` in settings parsing and reject empty/malformed values
- add startup ledger connectivity probe before binding HTTP/gRPC listeners
- add focused tests for settings validation and startup connectivity probe behavior

## Test plan
- cargo test settings::tests
- cargo test ledger_probe_tests