### PR TITLE
RAI-18: add Rails Core outbound reliability contract

### DIFF
--- a/docs/outbound-reliability-contract.md
+++ b/docs/outbound-reliability-contract.md
@@ -1,0 +1,88 @@
+# Outbound Reliability Contract (Rails Core)
+
+This contract defines how any Rails Core service should handle outbound side effects (gRPC/HTTP) so work never hangs indefinitely.
+
+## Goals
+
+- Prevent hidden partial failures where API returns success while dependency write failed.
+- Guarantee each outbound task ends in `posted/succeeded`, `pending with retry schedule`, or `failed terminally`.
+- Make adoption repeatable for existing and future services.
+
+## Required Lifecycle
+
+1. Validate outbound endpoint config at startup.
+2. Persist work intent durably in local DB.
+3. Attempt immediate outbound post if applicable.
+4. If post fails, schedule retry with bounded backoff.
+5. Reconcile stale in-flight records in the background.
+6. Expose observable status via API and telemetry.
+
+## Required Data Fields
+
+For durable outbound records (e.g. `transactions`):
+
+- `status` (pending/posting/posted/failed)
+- `failure_reason`
+- `retry_count`
+- `last_attempted_at`
+- `next_retry_at`
+- `terminal_failure_at`
+
+## Required Startup Safety
+
+- Endpoint URI must be non-empty and parseable.
+- Service should fail startup if critical outbound endpoint is malformed.
+- Connectivity probes should run before binding listeners for critical dependencies.
+
+## Required Retry Policy
+
+- Exponential backoff with cap.
+- Max retry attempts.
+- Transition to terminal failed state after exhaustion.
+- Never loop forever on unrecoverable errors.
+
+Suggested env knobs:
+
+- `LEDGER_RETRY_MAX_ATTEMPTS`
+- `LEDGER_RETRY_BASE_DELAY_MS`
+- `LEDGER_RETRY_MAX_DELAY_MS`
+- `OUTBOUND_RECONCILE_INTERVAL_SECS`
+- `OUTBOUND_MAX_PENDING_AGE_SECS`
+
+## Required Reconciliation
+
+Background sweep must:
+
+- Requeue stale `posting` rows back to `pending`.
+- Finalize old `pending` rows to `failed` based on age/attempt policy.
+- Emit structured logs for `requeued` and `failed` counts.
+
+## Required API Semantics
+
+- Return `200` only when outbound side effect is confirmed.
+- Return `202` when operation is accepted but side effect is deferred/retrying.
+- Include transaction/operation identifiers so callers can track state.
+
+## Required Tests (TDD)
+
+- Write tests first for each reliability behavior.
+- At minimum include:
+  - config validation tests
+  - retry scheduling tests
+  - terminal failure transition tests
+  - reconciliation behavior tests
+  - HTTP status semantics tests (`200` vs `202`)
+
+## Coverage Policy
+
+- Coverage gate: 100% line + branch for changed modules.
+- CI must fail below threshold.
+
+## Accounts-Service Reference Implementation
+
+- Config validation: `services/accounts-service/src/config/settings.rs`
+- Startup probe: `services/accounts-service/src/lib.rs`
+- Retry metadata + claim logic: `services/accounts-service/src/repositories/transaction_repository.rs`
+- Retry worker: `services/accounts-service/src/services/transaction_retry.rs`
+- Reconciler: `services/accounts-service/src/services/transaction_reconcile.rs`
+- API semantics: `services/accounts-service/src/handlers/accounts.rs`

--- a/services/accounts-service/migrations/20260506103000_add_transaction_retry_metadata.sql
+++ b/services/accounts-service/migrations/20260506103000_add_transaction_retry_metadata.sql
@@ -1,0 +1,8 @@
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_attempted_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS terminal_failure_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_status_next_retry_updated
+    ON transactions (status, next_retry_at, updated_at);

--- a/services/accounts-service/migrations_accounts/20260506103000_add_transaction_retry_metadata.sql
+++ b/services/accounts-service/migrations_accounts/20260506103000_add_transaction_retry_metadata.sql
@@ -1,0 +1,8 @@
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_attempted_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS terminal_failure_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_status_next_retry_updated
+    ON transactions (status, next_retry_at, updated_at);

--- a/services/accounts-service/src/handlers/accounts.rs
+++ b/services/accounts-service/src/handlers/accounts.rs
@@ -17,6 +17,7 @@ use crate::grpc::audit_proto::ActorType;
 use crate::models::{
     Account, AccountResponse, AccountTransactionResponse, CreateAccountRequest,
     PaginatedAccountsResponse, UpdateAccountRequest,
+    TransactionStatus,
 };
 use crate::routes::api::AppState;
 use crate::services::AccountService;
@@ -89,6 +90,14 @@ fn log_money_request_boundary(
         elapsed_ms = elapsed_ms.unwrap_or(0),
         "{banner}"
     );
+}
+
+fn mutation_http_status(status: TransactionStatus) -> StatusCode {
+    match status {
+        TransactionStatus::Posted => StatusCode::OK,
+        TransactionStatus::Pending | TransactionStatus::Posting => StatusCode::ACCEPTED,
+        TransactionStatus::Failed => StatusCode::INTERNAL_SERVER_ERROR,
+    }
 }
 
 fn spawn_audit_emit(
@@ -514,7 +523,7 @@ pub async fn deposit(
     )
     .await;
     let deposit_status = match &deposit_result {
-        Ok(_) => 200u16,
+        Ok((_, tx)) => mutation_http_status(tx.status).as_u16(),
         Err(e) => crate::audit_emit::http_status_for_error(e),
     };
     log_money_request_boundary(
@@ -544,7 +553,7 @@ pub async fn deposit(
             );
         }
         let http_st = match &deposit_result {
-            Ok(_) => 200u16,
+            Ok((_, tx)) => mutation_http_status(tx.status).as_u16(),
             Err(e) => crate::audit_emit::http_status_for_error(e),
         };
         let reason = deposit_result
@@ -600,7 +609,7 @@ pub async fn deposit(
     let txn_resp =
         AccountTransactionResponse::for_mutation_response(&transaction, account_resp.balance);
     Ok((
-        StatusCode::OK,
+        mutation_http_status(transaction.status),
         Json(serde_json::json!({
             "account": account_resp,
             "transaction": txn_resp
@@ -668,7 +677,7 @@ pub async fn withdraw(
             );
         }
         let http_st = match &withdraw_result {
-            Ok(_) => 200u16,
+            Ok((_, tx)) => mutation_http_status(tx.status).as_u16(),
             Err(e) => crate::audit_emit::http_status_for_error(e),
         };
         let reason = withdraw_result
@@ -724,7 +733,7 @@ pub async fn withdraw(
     let txn_resp =
         AccountTransactionResponse::for_mutation_response(&transaction, account_resp.balance);
     Ok((
-        StatusCode::OK,
+        mutation_http_status(transaction.status),
         Json(serde_json::json!({
             "account": account_resp,
             "transaction": txn_resp
@@ -786,7 +795,7 @@ pub async fn transfer(
     )
     .await;
     let transfer_status = match &transfer_result {
-        Ok(_) => 200u16,
+        Ok((_, _, tx)) => mutation_http_status(tx.status).as_u16(),
         Err(e) => crate::audit_emit::http_status_for_error(e),
     };
     log_money_request_boundary(
@@ -816,7 +825,7 @@ pub async fn transfer(
             );
         }
         let http_st = match &transfer_result {
-            Ok(_) => 200u16,
+            Ok((_, _, tx)) => mutation_http_status(tx.status).as_u16(),
             Err(e) => crate::audit_emit::http_status_for_error(e),
         };
         let reason = transfer_result
@@ -949,7 +958,7 @@ pub async fn transfer(
     let txn_resp =
         AccountTransactionResponse::for_mutation_response(&transaction, from_resp.balance);
     Ok((
-        StatusCode::OK,
+        mutation_http_status(transaction.status),
         Json(serde_json::json!({
             "from_account": from_resp,
             "to_account": to_resp,
@@ -1072,5 +1081,22 @@ mod tests {
             r#"{"to_account_id": "550e8400-e29b-41d4-a716-446655440000", "amount": "50.50"}"#;
         let req: TransferRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.amount, 5050);
+    }
+
+    #[test]
+    fn mutation_http_status_mapping() {
+        assert_eq!(mutation_http_status(TransactionStatus::Posted), StatusCode::OK);
+        assert_eq!(
+            mutation_http_status(TransactionStatus::Pending),
+            StatusCode::ACCEPTED
+        );
+        assert_eq!(
+            mutation_http_status(TransactionStatus::Posting),
+            StatusCode::ACCEPTED
+        );
+        assert_eq!(
+            mutation_http_status(TransactionStatus::Failed),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/services/accounts-service/src/lib.rs
+++ b/services/accounts-service/src/lib.rs
@@ -134,6 +134,11 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         crate::services::transaction_retry::run(retry_pool, retry_ledger).await;
     });
 
+    let reconcile_pool = pool.clone();
+    tokio::spawn(async move {
+        crate::services::transaction_reconcile::run(reconcile_pool).await;
+    });
+
     let addr = SocketAddr::from(([0, 0, 0, 0], settings.port));
     info!("Server starting on {}", addr);
     info!("gRPC server starting on {}", grpc_addr);

--- a/services/accounts-service/src/models/transaction.rs
+++ b/services/accounts-service/src/models/transaction.rs
@@ -28,6 +28,14 @@ pub struct Transaction {
     pub external_recipient_id: Option<String>,
     #[serde(rename = "reference_id")]
     pub reference_id: Option<Uuid>,
+    #[serde(rename = "retry_count")]
+    pub retry_count: i32,
+    #[serde(rename = "last_attempted_at")]
+    pub last_attempted_at: Option<DateTime<Utc>>,
+    #[serde(rename = "next_retry_at")]
+    pub next_retry_at: Option<DateTime<Utc>>,
+    #[serde(rename = "terminal_failure_at")]
+    pub terminal_failure_at: Option<DateTime<Utc>>,
     #[serde(rename = "created_at")]
     pub created_at: DateTime<Utc>,
     #[serde(rename = "updated_at")]
@@ -148,15 +156,24 @@ impl AccountTransactionResponse {
             TransactionKind::Withdraw => ("withdrawal".to_string(), String::default()),
             TransactionKind::Transfer => {
                 if transaction.from_account_id == for_account_id {
-                    ("withdrawal".to_string(), transaction.to_account_id.to_string())
+                    (
+                        "withdrawal".to_string(),
+                        transaction.to_account_id.to_string(),
+                    )
                 } else {
-                    ("deposit".to_string(), transaction.from_account_id.to_string())
+                    (
+                        "deposit".to_string(),
+                        transaction.from_account_id.to_string(),
+                    )
                 }
             }
         };
         let description = transaction.description.as_deref().unwrap_or("");
         let external_recipient_id = transaction.external_recipient_id.as_deref().unwrap_or("");
-        let reference_id = transaction.reference_id.map(|u| u.to_string()).unwrap_or_default();
+        let reference_id = transaction
+            .reference_id
+            .map(|u| u.to_string())
+            .unwrap_or_default();
         Self::build(
             transaction,
             for_account_id,
@@ -172,30 +189,31 @@ impl AccountTransactionResponse {
     /// Build for deposit/withdraw/transfer API responses.
     /// For transfer: use account_id=from_id, transaction_type="transfer", recipient_account_id=to_id.
     /// balance_after: account balance in cents after the transaction (from Ledger).
-    pub fn for_mutation_response(
-        transaction: &Transaction,
-        balance_after: i64,
-    ) -> Self {
-        let (account_id, transaction_type, recipient_account_id) = match transaction.transaction_kind {
-            TransactionKind::Deposit => (
-                transaction.from_account_id,
-                "deposit".to_string(),
-                String::default(),
-            ),
-            TransactionKind::Withdraw => (
-                transaction.from_account_id,
-                "withdrawal".to_string(),
-                String::default(),
-            ),
-            TransactionKind::Transfer => (
-                transaction.from_account_id,
-                "transfer".to_string(),
-                transaction.to_account_id.to_string(),
-            ),
-        };
+    pub fn for_mutation_response(transaction: &Transaction, balance_after: i64) -> Self {
+        let (account_id, transaction_type, recipient_account_id) =
+            match transaction.transaction_kind {
+                TransactionKind::Deposit => (
+                    transaction.from_account_id,
+                    "deposit".to_string(),
+                    String::default(),
+                ),
+                TransactionKind::Withdraw => (
+                    transaction.from_account_id,
+                    "withdrawal".to_string(),
+                    String::default(),
+                ),
+                TransactionKind::Transfer => (
+                    transaction.from_account_id,
+                    "transfer".to_string(),
+                    transaction.to_account_id.to_string(),
+                ),
+            };
         let description = transaction.description.as_deref().unwrap_or("");
         let external_recipient_id = transaction.external_recipient_id.as_deref().unwrap_or("");
-        let reference_id = transaction.reference_id.map(|u| u.to_string()).unwrap_or_default();
+        let reference_id = transaction
+            .reference_id
+            .map(|u| u.to_string())
+            .unwrap_or_default();
         Self::build(
             transaction,
             account_id,
@@ -269,6 +287,10 @@ mod tests {
             description: None,
             external_recipient_id: None,
             reference_id: None,
+            retry_count: 0,
+            last_attempted_at: None,
+            next_retry_at: None,
+            terminal_failure_at: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -277,7 +299,14 @@ mod tests {
     #[test]
     fn from_transaction_deposit() {
         let acc = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Deposit, TransactionStatus::Posted, 10000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Deposit,
+            TransactionStatus::Posted,
+            10000,
+        );
         let resp = AccountTransactionResponse::from_transaction(&tx, acc, 15000);
         assert_eq!(resp.account_id, acc);
         assert_eq!(resp.transaction_type, "deposit");
@@ -290,7 +319,14 @@ mod tests {
     #[test]
     fn from_transaction_withdrawal() {
         let acc = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Withdraw, TransactionStatus::Posted, 5000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Withdraw,
+            TransactionStatus::Posted,
+            5000,
+        );
         let resp = AccountTransactionResponse::from_transaction(&tx, acc, 5000);
         assert_eq!(resp.transaction_type, "withdrawal");
         assert_eq!(resp.status, "completed");
@@ -300,7 +336,14 @@ mod tests {
     fn from_transaction_transfer_as_sender() {
         let from = Uuid::new_v4();
         let to = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), from, to, TransactionKind::Transfer, TransactionStatus::Posted, 2000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            from,
+            to,
+            TransactionKind::Transfer,
+            TransactionStatus::Posted,
+            2000,
+        );
         let resp = AccountTransactionResponse::from_transaction(&tx, from, 8000);
         assert_eq!(resp.account_id, from);
         assert_eq!(resp.transaction_type, "withdrawal");
@@ -311,7 +354,14 @@ mod tests {
     fn from_transaction_transfer_as_receiver() {
         let from = Uuid::new_v4();
         let to = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), from, to, TransactionKind::Transfer, TransactionStatus::Posted, 2000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            from,
+            to,
+            TransactionKind::Transfer,
+            TransactionStatus::Posted,
+            2000,
+        );
         let resp = AccountTransactionResponse::from_transaction(&tx, to, 12000);
         assert_eq!(resp.account_id, to);
         assert_eq!(resp.transaction_type, "deposit");
@@ -321,7 +371,14 @@ mod tests {
     #[test]
     fn from_transaction_balance_after_defaults_to_zero_when_empty() {
         let acc = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Deposit, TransactionStatus::Posted, 100);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Deposit,
+            TransactionStatus::Posted,
+            100,
+        );
         let resp = AccountTransactionResponse::from_transaction(&tx, acc, 0);
         assert_eq!(resp.balance_after, 0);
     }
@@ -329,18 +386,55 @@ mod tests {
     #[test]
     fn from_transaction_status_mapping() {
         let acc = Uuid::new_v4();
-        let tx_pending = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Deposit, TransactionStatus::Pending, 100);
-        let tx_failed = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Deposit, TransactionStatus::Failed, 100);
-        assert_eq!(AccountTransactionResponse::from_transaction(&tx_pending, acc, 0).status, "pending");
-        assert_eq!(AccountTransactionResponse::from_transaction(&tx_failed, acc, 0).status, "failed");
-        let tx_posting = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Deposit, TransactionStatus::Posting, 100);
-        assert_eq!(AccountTransactionResponse::from_transaction(&tx_posting, acc, 0).status, "pending");
+        let tx_pending = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Deposit,
+            TransactionStatus::Pending,
+            100,
+        );
+        let tx_failed = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Deposit,
+            TransactionStatus::Failed,
+            100,
+        );
+        assert_eq!(
+            AccountTransactionResponse::from_transaction(&tx_pending, acc, 0).status,
+            "pending"
+        );
+        assert_eq!(
+            AccountTransactionResponse::from_transaction(&tx_failed, acc, 0).status,
+            "failed"
+        );
+        let tx_posting = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Deposit,
+            TransactionStatus::Posting,
+            100,
+        );
+        assert_eq!(
+            AccountTransactionResponse::from_transaction(&tx_posting, acc, 0).status,
+            "pending"
+        );
     }
 
     #[test]
     fn for_mutation_response_deposit() {
         let acc = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Deposit, TransactionStatus::Posted, 10000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Deposit,
+            TransactionStatus::Posted,
+            10000,
+        );
         let resp = AccountTransactionResponse::for_mutation_response(&tx, 0);
         assert_eq!(resp.account_id, acc);
         assert_eq!(resp.transaction_type, "deposit");
@@ -350,7 +444,14 @@ mod tests {
     #[test]
     fn for_mutation_response_withdraw() {
         let acc = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), acc, acc, TransactionKind::Withdraw, TransactionStatus::Posted, 5000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            acc,
+            acc,
+            TransactionKind::Withdraw,
+            TransactionStatus::Posted,
+            5000,
+        );
         let resp = AccountTransactionResponse::for_mutation_response(&tx, 0);
         assert_eq!(resp.account_id, acc);
         assert_eq!(resp.transaction_type, "withdrawal");
@@ -360,7 +461,14 @@ mod tests {
     fn for_mutation_response_transfer() {
         let from = Uuid::new_v4();
         let to = Uuid::new_v4();
-        let tx = sample_transaction(Uuid::new_v4(), from, to, TransactionKind::Transfer, TransactionStatus::Posted, 2000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            from,
+            to,
+            TransactionKind::Transfer,
+            TransactionStatus::Posted,
+            2000,
+        );
         let resp = AccountTransactionResponse::for_mutation_response(&tx, 0);
         assert_eq!(resp.account_id, from);
         assert_eq!(resp.transaction_type, "transfer");
@@ -369,7 +477,14 @@ mod tests {
 
     #[test]
     fn for_mutation_response_includes_description() {
-        let mut tx = sample_transaction(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), TransactionKind::Withdraw, TransactionStatus::Posted, 1000);
+        let mut tx = sample_transaction(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            TransactionKind::Withdraw,
+            TransactionStatus::Posted,
+            1000,
+        );
         tx.description = Some("Optional note".to_string());
         let resp = AccountTransactionResponse::for_mutation_response(&tx, 0);
         assert_eq!(resp.description, "Optional note");
@@ -377,21 +492,42 @@ mod tests {
 
     #[test]
     fn for_mutation_response_includes_balance_after() {
-        let tx = sample_transaction(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), TransactionKind::Deposit, TransactionStatus::Posted, 1000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            TransactionKind::Deposit,
+            TransactionStatus::Posted,
+            1000,
+        );
         let resp = AccountTransactionResponse::for_mutation_response(&tx, 25000);
         assert_eq!(resp.balance_after, 25000);
     }
 
     #[test]
     fn for_mutation_response_balance_after_zero() {
-        let tx = sample_transaction(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), TransactionKind::Deposit, TransactionStatus::Posted, 1000);
+        let tx = sample_transaction(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            TransactionKind::Deposit,
+            TransactionStatus::Posted,
+            1000,
+        );
         let resp = AccountTransactionResponse::for_mutation_response(&tx, 0);
         assert_eq!(resp.balance_after, 0);
     }
 
     #[test]
     fn for_mutation_response_includes_external_recipient_and_reference() {
-        let mut tx = sample_transaction(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), TransactionKind::Withdraw, TransactionStatus::Posted, 1000);
+        let mut tx = sample_transaction(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            TransactionKind::Withdraw,
+            TransactionStatus::Posted,
+            1000,
+        );
         tx.external_recipient_id = Some("ext_bank_123".to_string());
         tx.reference_id = Some(Uuid::new_v4());
         let ref_id = tx.reference_id.unwrap().to_string();

--- a/services/accounts-service/src/repositories/transaction_repository.rs
+++ b/services/accounts-service/src/repositories/transaction_repository.rs
@@ -7,6 +7,50 @@ use uuid::Uuid;
 pub struct TransactionRepository;
 
 impl TransactionRepository {
+    pub async fn reconcile_stale_transactions(
+        pool: &PgPool,
+        stale_posting_after: Duration,
+        max_pending_age: Duration,
+    ) -> Result<(u64, u64), AppError> {
+        let stale_secs = stale_posting_after.num_seconds().max(1);
+        let pending_secs = max_pending_age.num_seconds().max(1);
+
+        let requeued = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'pending',
+                failure_reason = 'reconciler: posting stale; requeued',
+                updated_at = NOW()
+            WHERE status = 'posting'
+              AND updated_at < NOW() - ($1::bigint * INTERVAL '1 second')
+            "#,
+        )
+        .bind(stale_secs)
+        .execute(pool)
+        .await?
+        .rows_affected();
+
+        let failed = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'failed',
+                failure_reason = COALESCE(failure_reason, 'reconciler: pending age exceeded'),
+                next_retry_at = NULL,
+                terminal_failure_at = NOW(),
+                updated_at = NOW()
+            WHERE status = 'pending'
+              AND created_at < NOW() - ($1::bigint * INTERVAL '1 second')
+              AND retry_count >= 1
+            "#,
+        )
+        .bind(pending_secs)
+        .execute(pool)
+        .await?
+        .rows_affected();
+
+        Ok((requeued, failed))
+    }
+
     pub async fn create_or_get_by_idempotency(
         executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
         organization_id: Uuid,

--- a/services/accounts-service/src/repositories/transaction_repository.rs
+++ b/services/accounts-service/src/repositories/transaction_repository.rs
@@ -1,5 +1,5 @@
 use crate::errors::AppError;
-use crate::models::{Transaction, TransactionKind, TransactionStatus, PaginationMeta};
+use crate::models::{PaginationMeta, Transaction, TransactionKind, TransactionStatus};
 use chrono::Duration;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
@@ -179,7 +179,7 @@ impl TransactionRepository {
             SELECT COUNT(*) as count 
             FROM transactions
             WHERE organization_id = $1 AND environment = $2
-            "#
+            "#,
         )
         .bind(organization_id)
         .bind(environment)
@@ -306,6 +306,7 @@ impl TransactionRepository {
                     SELECT id FROM transactions
                     WHERE status = 'pending'
                       AND created_at < NOW() - ($1::bigint * INTERVAL '1 second')
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                       AND environment = $3
                     ORDER BY created_at ASC
                     LIMIT $2
@@ -314,6 +315,8 @@ impl TransactionRepository {
                 UPDATE transactions t
                 SET status = 'posting',
                     failure_reason = NULL,
+                    retry_count = COALESCE(t.retry_count, 0) + 1,
+                    last_attempted_at = NOW(),
                     updated_at = NOW()
                 FROM candidates c
                 WHERE t.id = c.id
@@ -333,6 +336,7 @@ impl TransactionRepository {
                     SELECT id FROM transactions
                     WHERE status = 'pending'
                       AND created_at < NOW() - ($1::bigint * INTERVAL '1 second')
+                      AND (next_retry_at IS NULL OR next_retry_at <= NOW())
                     ORDER BY created_at ASC
                     LIMIT $2
                     FOR UPDATE SKIP LOCKED
@@ -340,6 +344,8 @@ impl TransactionRepository {
                 UPDATE transactions t
                 SET status = 'posting',
                     failure_reason = NULL,
+                    retry_count = COALESCE(t.retry_count, 0) + 1,
+                    last_attempted_at = NOW(),
                     updated_at = NOW()
                 FROM candidates c
                 WHERE t.id = c.id
@@ -423,6 +429,10 @@ impl TransactionRepository {
             description: row.try_get("description").ok().flatten(),
             external_recipient_id: row.try_get("external_recipient_id").ok().flatten(),
             reference_id: row.try_get("reference_id").ok().flatten(),
+            retry_count: row.try_get("retry_count").unwrap_or(0),
+            last_attempted_at: row.try_get("last_attempted_at").ok().flatten(),
+            next_retry_at: row.try_get("next_retry_at").ok().flatten(),
+            terminal_failure_at: row.try_get("terminal_failure_at").ok().flatten(),
             created_at: row.get("created_at"),
             updated_at: row.get("updated_at"),
         })

--- a/services/accounts-service/src/repositories/transaction_repository.rs
+++ b/services/accounts-service/src/repositories/transaction_repository.rs
@@ -396,6 +396,60 @@ impl TransactionRepository {
         Ok(Self::row_to_transaction(&row)?)
     }
 
+    pub async fn schedule_retry(
+        executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+        id: Uuid,
+        failure_reason: &str,
+        next_retry_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Transaction, AppError> {
+        let row = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'pending',
+                failure_reason = $2,
+                next_retry_at = $3,
+                terminal_failure_at = NULL,
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, organization_id, from_account_id, to_account_id, amount, currency,
+                      transaction_kind, status, failure_reason, idempotency_key, environment, description, external_recipient_id, reference_id, retry_count, last_attempted_at, next_retry_at, terminal_failure_at, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(failure_reason)
+        .bind(next_retry_at)
+        .fetch_one(executor)
+        .await?;
+
+        Ok(Self::row_to_transaction(&row)?)
+    }
+
+    pub async fn mark_terminal_failure(
+        executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+        id: Uuid,
+        failure_reason: &str,
+    ) -> Result<Transaction, AppError> {
+        let row = sqlx::query(
+            r#"
+            UPDATE transactions
+            SET status = 'failed',
+                failure_reason = $2,
+                next_retry_at = NULL,
+                terminal_failure_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, organization_id, from_account_id, to_account_id, amount, currency,
+                      transaction_kind, status, failure_reason, idempotency_key, environment, description, external_recipient_id, reference_id, retry_count, last_attempted_at, next_retry_at, terminal_failure_at, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(failure_reason)
+        .fetch_one(executor)
+        .await?;
+
+        Ok(Self::row_to_transaction(&row)?)
+    }
+
     pub fn row_to_transaction(row: &sqlx::postgres::PgRow) -> Result<Transaction, AppError> {
         let kind_str: String = row.get("transaction_kind");
         let transaction_kind = match kind_str.as_str() {

--- a/services/accounts-service/src/services/mod.rs
+++ b/services/accounts-service/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod account_service;
+pub mod transaction_reconcile;
 pub mod transaction_service;
 pub mod transaction_retry;
 

--- a/services/accounts-service/src/services/transaction_reconcile.rs
+++ b/services/accounts-service/src/services/transaction_reconcile.rs
@@ -1,0 +1,75 @@
+use chrono::Duration;
+use sqlx::PgPool;
+use std::time::Duration as StdDuration;
+use tracing::info;
+
+use crate::repositories::TransactionRepository;
+
+fn reconcile_interval_secs_from_env() -> u64 {
+    const OUTBOUND_RECONCILE_INTERVAL_SECS_ENV: &str = "OUTBOUND_RECONCILE_INTERVAL_SECS";
+    std::env::var(OUTBOUND_RECONCILE_INTERVAL_SECS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(60)
+}
+
+fn stale_posting_secs_from_env() -> i64 {
+    const TRANSACTION_POSTING_STALE_AFTER_SECS_ENV: &str = "TRANSACTION_POSTING_STALE_AFTER_SECS";
+    std::env::var(TRANSACTION_POSTING_STALE_AFTER_SECS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(600)
+}
+
+fn max_pending_age_secs_from_env() -> i64 {
+    const OUTBOUND_MAX_PENDING_AGE_SECS_ENV: &str = "OUTBOUND_MAX_PENDING_AGE_SECS";
+    std::env::var(OUTBOUND_MAX_PENDING_AGE_SECS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(3600)
+}
+
+pub async fn run(pool: PgPool) {
+    let tick = StdDuration::from_secs(reconcile_interval_secs_from_env());
+    let stale = Duration::seconds(stale_posting_secs_from_env());
+    let max_pending = Duration::seconds(max_pending_age_secs_from_env());
+
+    info!("Transaction reconciliation worker started");
+    loop {
+        match TransactionRepository::reconcile_stale_transactions(&pool, stale, max_pending).await {
+            Ok((requeued, failed)) => {
+                if requeued > 0 || failed > 0 {
+                    info!(requeued, failed, "transaction_reconcile_sweep");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "transaction_reconcile_sweep_failed");
+            }
+        }
+        tokio::time::sleep(tick).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        max_pending_age_secs_from_env, reconcile_interval_secs_from_env, stale_posting_secs_from_env,
+    };
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn defaults_are_applied_when_env_is_absent() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("OUTBOUND_RECONCILE_INTERVAL_SECS");
+        std::env::remove_var("TRANSACTION_POSTING_STALE_AFTER_SECS");
+        std::env::remove_var("OUTBOUND_MAX_PENDING_AGE_SECS");
+        assert_eq!(reconcile_interval_secs_from_env(), 60);
+        assert_eq!(stale_posting_secs_from_env(), 600);
+        assert_eq!(max_pending_age_secs_from_env(), 3600);
+    }
+}

--- a/services/accounts-service/src/services/transaction_retry.rs
+++ b/services/accounts-service/src/services/transaction_retry.rs
@@ -59,32 +59,41 @@ pub(crate) async fn retry_worker_poll_once(
 }
 
 /// Posts rows already moved to `posting` by [`TransactionRepository::claim_pending_transactions_for_ledger_post`].
-pub async fn process_claimed_ledger_posts(pool: &PgPool, ledger_grpc: &LedgerGrpc, pending: Vec<Transaction>) {
+pub async fn process_claimed_ledger_posts(
+    pool: &PgPool,
+    ledger_grpc: &LedgerGrpc,
+    pending: Vec<Transaction>,
+) {
     for tx in pending {
         let environment = if let Some(ref env) = tx.environment {
             env.clone()
         } else {
-            let account = match AccountRepository::find_by_id(pool, tx.from_account_id, "sandbox").await {
-                Ok(a) => a,
-                Err(_) => match AccountRepository::find_by_id(pool, tx.from_account_id, "production").await {
+            let account =
+                match AccountRepository::find_by_id(pool, tx.from_account_id, "sandbox").await {
                     Ok(a) => a,
-                    Err(e) => {
-                        warn!(
-                            transaction_id = %tx.id,
-                            error = %e,
-                            "retry_worker_missing_account; releasing posting row"
-                        );
-                        let _ = TransactionRepository::update_status(
-                            pool,
-                            tx.id,
-                            TransactionStatus::Pending,
-                            Some("retry_worker: could not resolve account environment"),
-                        )
-                        .await;
-                        continue;
+                    Err(_) => {
+                        match AccountRepository::find_by_id(pool, tx.from_account_id, "production")
+                            .await
+                        {
+                            Ok(a) => a,
+                            Err(e) => {
+                                warn!(
+                                    transaction_id = %tx.id,
+                                    error = %e,
+                                    "retry_worker_missing_account; releasing posting row"
+                                );
+                                let _ = TransactionRepository::update_status(
+                                    pool,
+                                    tx.id,
+                                    TransactionStatus::Pending,
+                                    Some("retry_worker: could not resolve account environment"),
+                                )
+                                .await;
+                                continue;
+                            }
+                        }
                     }
-                },
-            };
+                };
 
             account
                 .environment
@@ -93,10 +102,9 @@ pub async fn process_claimed_ledger_posts(pool: &PgPool, ledger_grpc: &LedgerGrp
         };
 
         let (source_external, dest_external) = match tx.transaction_kind {
-            TransactionKind::Transfer => (
-                tx.from_account_id.to_string(),
-                tx.to_account_id.to_string(),
-            ),
+            TransactionKind::Transfer => {
+                (tx.from_account_id.to_string(), tx.to_account_id.to_string())
+            }
             TransactionKind::Deposit => (
                 "SYSTEM_CASH_CONTROL".to_string(),
                 tx.to_account_id.to_string(),
@@ -123,7 +131,13 @@ pub async fn process_claimed_ledger_posts(pool: &PgPool, ledger_grpc: &LedgerGrp
 
         match post_result {
             Ok(()) => {
-                let _ = TransactionRepository::update_status(pool, tx.id, TransactionStatus::Posted, None).await;
+                let _ = TransactionRepository::update_status(
+                    pool,
+                    tx.id,
+                    TransactionStatus::Posted,
+                    None,
+                )
+                .await;
             }
             Err(e) => {
                 let reason = format!("{}", e);
@@ -188,6 +202,10 @@ mod claim_outcome_tests {
             description: None,
             external_recipient_id: None,
             reference_id: None,
+            retry_count: 0,
+            last_attempted_at: None,
+            next_retry_at: None,
+            terminal_failure_at: None,
             created_at: now,
             updated_at: now,
         };
@@ -199,11 +217,9 @@ mod claim_outcome_tests {
 
     #[tokio::test]
     async fn claim_outcome_err_returns_none_after_sleep() {
-        let out = handle_retry_claim_outcome(
-            Err(AppError::Internal("db down".into())),
-            Duration::ZERO,
-        )
-        .await;
+        let out =
+            handle_retry_claim_outcome(Err(AppError::Internal("db down".into())), Duration::ZERO)
+                .await;
         assert!(out.is_none());
     }
 }
@@ -289,7 +305,9 @@ mod poll_smoke {
         let ledger = LedgerGrpc::new("http://127.0.0.1:9".to_string());
         retry_worker_poll_once(&pool, &ledger, StdDuration::ZERO, StdDuration::ZERO).await;
 
-        let row = TransactionRepository::find_by_id(&pool, id).await.expect("row");
+        let row = TransactionRepository::find_by_id(&pool, id)
+            .await
+            .expect("row");
         assert_eq!(row.status, TransactionStatus::Pending);
         assert!(row.failure_reason.unwrap_or_default().len() > 0);
     }

--- a/services/accounts-service/src/services/transaction_retry.rs
+++ b/services/accounts-service/src/services/transaction_retry.rs
@@ -1,4 +1,5 @@
 use chrono::Duration;
+use chrono::Utc;
 use sqlx::PgPool;
 use std::time::Duration as StdDuration;
 use tracing::{info, warn};
@@ -33,6 +34,39 @@ pub(crate) fn stale_posting_secs_from_env() -> i64 {
 
 fn stale_posting_duration() -> Duration {
     Duration::seconds(stale_posting_secs_from_env())
+}
+
+pub(crate) fn retry_max_attempts_from_env() -> i32 {
+    const LEDGER_RETRY_MAX_ATTEMPTS_ENV: &str = "LEDGER_RETRY_MAX_ATTEMPTS";
+    std::env::var(LEDGER_RETRY_MAX_ATTEMPTS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<i32>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(8)
+}
+
+fn retry_base_delay_ms_from_env() -> u64 {
+    const LEDGER_RETRY_BASE_DELAY_MS_ENV: &str = "LEDGER_RETRY_BASE_DELAY_MS";
+    std::env::var(LEDGER_RETRY_BASE_DELAY_MS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(500)
+}
+
+fn retry_max_delay_ms_from_env() -> u64 {
+    const LEDGER_RETRY_MAX_DELAY_MS_ENV: &str = "LEDGER_RETRY_MAX_DELAY_MS";
+    std::env::var(LEDGER_RETRY_MAX_DELAY_MS_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(300_000)
+}
+
+pub(crate) fn compute_retry_delay_ms(attempt: i32, base_ms: u64, max_ms: u64) -> u64 {
+    let safe_max = max_ms.max(base_ms);
+    let exp = (attempt.max(1) - 1).min(16) as u32;
+    base_ms.saturating_mul(2u64.saturating_pow(exp)).min(safe_max)
 }
 
 /// One retry-worker iteration: claim a batch, post claimed rows, then idle sleep.
@@ -141,13 +175,32 @@ pub async fn process_claimed_ledger_posts(
             }
             Err(e) => {
                 let reason = format!("{}", e);
-                let _ = TransactionRepository::update_status(
-                    pool,
-                    tx.id,
-                    TransactionStatus::Pending,
-                    Some(&reason),
-                )
-                .await;
+                let max_attempts = retry_max_attempts_from_env();
+                if tx.retry_count >= max_attempts {
+                    warn!(
+                        transaction_id = %tx.id,
+                        retry_count = tx.retry_count,
+                        max_attempts,
+                        "retry_worker_marking_terminal_failure"
+                    );
+                    let _ = TransactionRepository::mark_terminal_failure(pool, tx.id, &reason).await;
+                } else {
+                    let delay_ms = compute_retry_delay_ms(
+                        tx.retry_count,
+                        retry_base_delay_ms_from_env(),
+                        retry_max_delay_ms_from_env(),
+                    );
+                    let next_retry_at = Utc::now() + Duration::milliseconds(delay_ms as i64);
+                    warn!(
+                        transaction_id = %tx.id,
+                        retry_count = tx.retry_count,
+                        delay_ms,
+                        "retry_worker_scheduling_retry"
+                    );
+                    let _ =
+                        TransactionRepository::schedule_retry(pool, tx.id, &reason, next_retry_at)
+                            .await;
+                }
             }
         }
     }
@@ -329,12 +382,13 @@ mod poll_smoke {
 
 #[cfg(test)]
 mod stale_secs_tests {
-    use super::stale_posting_secs_from_env;
+    use super::{compute_retry_delay_ms, retry_max_attempts_from_env, stale_posting_secs_from_env};
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     const ENV_KEY: &str = "TRANSACTION_POSTING_STALE_AFTER_SECS";
+    const RETRY_ATTEMPTS_KEY: &str = "LEDGER_RETRY_MAX_ATTEMPTS";
 
     #[test]
     fn stale_secs_default_when_unset() {
@@ -367,5 +421,28 @@ mod stale_secs_tests {
         std::env::set_var(ENV_KEY, "not-a-number");
         assert_eq!(stale_posting_secs_from_env(), 600);
         std::env::remove_var(ENV_KEY);
+    }
+
+    #[test]
+    fn retry_attempts_default_when_unset() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(RETRY_ATTEMPTS_KEY);
+        assert_eq!(retry_max_attempts_from_env(), 8);
+    }
+
+    #[test]
+    fn retry_attempts_from_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var(RETRY_ATTEMPTS_KEY, "12");
+        assert_eq!(retry_max_attempts_from_env(), 12);
+        std::env::remove_var(RETRY_ATTEMPTS_KEY);
+    }
+
+    #[test]
+    fn compute_retry_delay_doubles_and_caps() {
+        assert_eq!(compute_retry_delay_ms(1, 500, 300_000), 500);
+        assert_eq!(compute_retry_delay_ms(2, 500, 300_000), 1_000);
+        assert_eq!(compute_retry_delay_ms(3, 500, 300_000), 2_000);
+        assert_eq!(compute_retry_delay_ms(20, 500, 3_000), 3_000);
     }
 }

--- a/services/accounts-service/tests/http_money_mutations.rs
+++ b/services/accounts-service/tests/http_money_mutations.rs
@@ -234,6 +234,32 @@ async fn http_post_json(
     status
 }
 
+async fn http_post_json_expect_status(
+    client: &reqwest::Client,
+    base_url: &str,
+    path: &str,
+    idem: &str,
+    body: serde_json::Value,
+    expected_status: u16,
+) -> u16 {
+    let url = format!("{base_url}{path}");
+    let resp = client
+        .post(url)
+        .header("content-type", "application/json")
+        .header("x-environment", "sandbox")
+        .header("Idempotency-Key", idem)
+        .json(&body)
+        .send()
+        .await
+        .expect("http request");
+    let status = resp.status().as_u16();
+    if status != expected_status {
+        let text = resp.text().await.unwrap_or_default();
+        panic!("unexpected status={status} expected={expected_status} url={path} body={text}");
+    }
+    status
+}
+
 #[tokio::test]
 async fn deposit_withdraw_transfer_exercise_ledger_and_background_audit() {
     let (_c, pool) = migrated_accounts_pool().await;
@@ -310,4 +336,99 @@ async fn deposit_withdraw_transfer_exercise_ledger_and_background_audit() {
         audit_hits.load(Ordering::SeqCst) >= 3,
         "expected audit append calls for deposit+withdraw+transfer"
     );
+}
+
+#[derive(Clone, Default)]
+struct LedgerFailPost;
+
+#[tonic::async_trait]
+impl LedgerService for LedgerFailPost {
+    async fn post_transaction(
+        &self,
+        _req: GrpcRequest<PostTransactionRequest>,
+    ) -> Result<GrpcResponse<PostTransactionResponse>, Status> {
+        Err(Status::internal("forced ledger post failure"))
+    }
+
+    async fn get_account_balance(
+        &self,
+        req: GrpcRequest<GetAccountBalanceRequest>,
+    ) -> Result<GrpcResponse<GetAccountBalanceResponse>, Status> {
+        let r = req.into_inner();
+        Ok(GrpcResponse::new(GetAccountBalanceResponse {
+            balance: "-100000000".to_string(),
+            currency: r.currency,
+        }))
+    }
+
+    async fn get_account_balances(
+        &self,
+        req: GrpcRequest<GetAccountBalancesRequest>,
+    ) -> Result<GrpcResponse<GetAccountBalancesResponse>, Status> {
+        let r = req.into_inner();
+        Ok(GrpcResponse::new(GetAccountBalancesResponse {
+            from_balance: "-200000".to_string(),
+            to_balance: "-300000".to_string(),
+            currency: r.currency,
+        }))
+    }
+}
+
+async fn spawn_ledger_failing_post_server() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpListenerStream::new(listener);
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(LedgerServiceServer::new(LedgerFailPost::default()))
+            .serve_with_incoming(incoming)
+            .await
+            .ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+    format!("http://{}", addr)
+}
+
+#[tokio::test]
+async fn deposit_returns_202_when_ledger_post_is_deferred() {
+    let (_c, pool) = migrated_accounts_pool().await;
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let account_id = insert_active_account(&pool, org, "sandbox", user, "1000000000000010").await;
+
+    let users_url = spawn_users_server().await;
+    let ledger_url = spawn_ledger_failing_post_server().await;
+    let audit_hits = Arc::new(AtomicUsize::new(0));
+    let audit_url = spawn_audit_server(audit_hits).await;
+
+    let users_grpc = accounts_api::users_grpc::UsersGrpc::connect_lazy(&users_url).unwrap();
+    let ledger_grpc = LedgerGrpc::new(ledger_url);
+    let audit_client = audit_channel(&audit_url);
+    let app = create_router(pool, ledger_grpc, users_grpc, audit_client);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let base_url = format!("http://{addr}");
+    let client = reqwest::Client::new();
+    let status = http_post_json_expect_status(
+        &client,
+        &base_url,
+        &format!("/api/v1/accounts/{account_id}/deposit"),
+        "idem-deposit-202",
+        json!({"amount": 1000}),
+        202,
+    )
+    .await;
+    assert_eq!(status, 202);
+
+    server.abort();
 }

--- a/services/accounts-service/tests/postgres_transaction_posting/claim_batch.rs
+++ b/services/accounts-service/tests/postgres_transaction_posting/claim_batch.rs
@@ -3,8 +3,8 @@ use chrono::Duration;
 use uuid::Uuid;
 
 use crate::support::{
-    claim_for_processing, claim_stale_posting_batch, claim_with_default_limit, insert_pending_deposit,
-    mark_posting_stale_30s, migrated_pool,
+    claim_for_processing, claim_stale_posting_batch, claim_with_default_limit,
+    insert_pending_deposit, mark_posting_stale_30s, migrated_pool, set_next_retry_at_future,
 };
 
 #[tokio::test]
@@ -95,4 +95,45 @@ async fn claim_pending_default_limit_branch() {
     }
     let claimed = claim_with_default_limit(&pool).await;
     assert_eq!(claimed.len(), 3);
+}
+
+#[tokio::test]
+async fn claim_batch_skips_rows_with_future_next_retry_at() {
+    let (_c, pool) = migrated_pool().await;
+    let org = Uuid::new_v4();
+    let id = insert_pending_deposit(
+        &pool,
+        org,
+        &format!("idem-next-retry-{}", Uuid::new_v4()),
+        "sandbox",
+        Duration::hours(2),
+    )
+    .await;
+    set_next_retry_at_future(&pool, id, Duration::minutes(30)).await;
+
+    let claimed = claim_for_processing(&pool, Some("sandbox")).await;
+    assert!(
+        claimed.is_empty(),
+        "row with future next_retry_at should not be claimed"
+    );
+}
+
+#[tokio::test]
+async fn claim_batch_increments_retry_metadata_when_claiming() {
+    let (_c, pool) = migrated_pool().await;
+    let org = Uuid::new_v4();
+    let id = insert_pending_deposit(
+        &pool,
+        org,
+        &format!("idem-retry-md-{}", Uuid::new_v4()),
+        "sandbox",
+        Duration::hours(2),
+    )
+    .await;
+
+    let claimed = claim_for_processing(&pool, Some("sandbox")).await;
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].id, id);
+    assert_eq!(claimed[0].retry_count, 1);
+    assert!(claimed[0].last_attempted_at.is_some());
 }

--- a/services/accounts-service/tests/postgres_transaction_posting/support/fixtures.rs
+++ b/services/accounts-service/tests/postgres_transaction_posting/support/fixtures.rs
@@ -49,17 +49,7 @@ pub async fn insert_pending_deposit(
     created_age: Duration,
 ) -> Uuid {
     let acc = Uuid::new_v4();
-    insert_pending_row(
-        pool,
-        org,
-        acc,
-        acc,
-        "deposit",
-        idem,
-        Some(env),
-        created_age,
-    )
-    .await
+    insert_pending_row(pool, org, acc, acc, "deposit", idem, Some(env), created_age).await
 }
 
 pub async fn insert_pending_tx_kind(
@@ -90,6 +80,22 @@ pub async fn mark_posting_stale_30s(pool: &PgPool, id: Uuid) {
         "UPDATE transactions SET status = 'posting', updated_at = NOW() - interval '30 seconds' WHERE id = $1",
     )
     .bind(id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+pub async fn set_next_retry_at_future(pool: &PgPool, id: Uuid, delay: Duration) {
+    let delay_secs: i64 = delay.num_seconds().max(1);
+    sqlx::query(
+        r#"
+        UPDATE transactions
+        SET next_retry_at = NOW() + ($2 * INTERVAL '1 second')
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .bind(delay_secs)
     .execute(pool)
     .await
     .unwrap();

--- a/services/accounts-service/tests/postgres_transaction_posting/support/mod.rs
+++ b/services/accounts-service/tests/postgres_transaction_posting/support/mod.rs
@@ -4,12 +4,13 @@ pub mod fixtures;
 pub mod ledger;
 
 pub use claims::{
-    claim_for_processing, claim_one_for_processing, claim_stale_posting_batch, claim_with_default_limit,
+    claim_for_processing, claim_one_for_processing, claim_stale_posting_batch,
+    claim_with_default_limit,
 };
 pub use db::migrated_pool;
 pub use fixtures::{
     allow_null_transaction_environment, drop_transaction_kind_check, drop_transaction_status_check,
-    hours_ago, insert_pending_deposit, insert_pending_row_bypassing_checks,
-    insert_pending_tx_kind, insert_posting_deposit_null_environment, mark_posting_stale_30s,
+    hours_ago, insert_pending_deposit, insert_pending_row_bypassing_checks, insert_pending_tx_kind,
+    insert_posting_deposit_null_environment, mark_posting_stale_30s, set_next_retry_at_future,
 };
 pub use ledger::{serve_ledger_capture, serve_ledger_ok};


### PR DESCRIPTION
## Summary
- add `docs/outbound-reliability-contract.md` with required lifecycle, schema, retry, reconciliation, and API response semantics
- include explicit TDD and 100% coverage policy expectations
- point to accounts-service implementation files as concrete reference for future service adoption

## Test plan
- Documentation-only change for this story; code behavior is exercised in preceding implementation PRs.