### PR TITLE
fix(ci): align ledger-service paths with root build context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,14 +116,14 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
     defaults:
       run:
-        working-directory: services/ledger-service
+        working-directory: ledger-service
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-          working-directory: services/ledger-service
+          working-directory: ledger-service
       - run: bundle exec rails db:test:prepare test
 
   # SonarQube scan disabled for now; keep Rust + Ledger coverage and Codecov uploads.
@@ -209,10 +209,10 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-          working-directory: services/ledger-service
+          working-directory: ledger-service
 
       - name: Ledger coverage (Rails tests)
-        working-directory: services/ledger-service
+        working-directory: ledger-service
         env:
           COVERAGE: "true"
         run: bundle exec rails db:test:prepare test
@@ -227,7 +227,7 @@ jobs:
             coverage-rust/users.lcov.info,
             coverage-rust/accounts.lcov.info,
             coverage-rust/audit.lcov.info,
-            services/ledger-service/coverage/lcov.info
+            ledger-service/coverage/lcov.info
 
       # - name: SonarQube Scan
       #   uses: SonarSource/sonarqube-scan-action@v6
@@ -240,9 +240,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [users-service, accounts-service, audit-service, ledger-service]
+        include:
+          - service: users-service
+            path: services/users-service
+          - service: accounts-service
+            path: services/accounts-service
+          - service: audit-service
+            path: services/audit-service
+          - service: ledger-service
+            path: ledger-service
     steps:
       - uses: actions/checkout@v4
       - name: Build image
-        working-directory: services/${{ matrix.service }}
+        working-directory: ${{ matrix.path }}
         run: docker build -t "${{ matrix.service }}:ci" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,17 +114,23 @@ jobs:
     env:
       RAILS_ENV: test
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ledger_test
-    defaults:
-      run:
-        working-directory: ledger-service
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve ledger service path
+        id: ledger-path
+        run: |
+          if [ -d ledger-service ]; then
+            echo "path=ledger-service" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=services/ledger-service" >> "$GITHUB_OUTPUT"
+          fi
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-          working-directory: ledger-service
+          working-directory: ${{ steps.ledger-path.outputs.path }}
       - run: bundle exec rails db:test:prepare test
+        working-directory: ${{ steps.ledger-path.outputs.path }}
 
   # SonarQube scan disabled for now; keep Rust + Ledger coverage and Codecov uploads.
   coverage:
@@ -205,14 +211,22 @@ jobs:
             --ignore-filename-regex '(^|/)src/main\.rs$' \
             -- --include-ignored
 
+      - name: Resolve ledger service path (coverage)
+        id: ledger-path-coverage
+        run: |
+          if [ -d ledger-service ]; then
+            echo "path=ledger-service" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=services/ledger-service" >> "$GITHUB_OUTPUT"
+          fi
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-          working-directory: ledger-service
+          working-directory: ${{ steps.ledger-path-coverage.outputs.path }}
 
       - name: Ledger coverage (Rails tests)
-        working-directory: ledger-service
+        working-directory: ${{ steps.ledger-path-coverage.outputs.path }}
         env:
           COVERAGE: "true"
         run: bundle exec rails db:test:prepare test
@@ -227,7 +241,7 @@ jobs:
             coverage-rust/users.lcov.info,
             coverage-rust/accounts.lcov.info,
             coverage-rust/audit.lcov.info,
-            ledger-service/coverage/lcov.info
+            ${{ steps.ledger-path-coverage.outputs.path }}/coverage/lcov.info
 
       # - name: SonarQube Scan
       #   uses: SonarSource/sonarqube-scan-action@v6
@@ -240,17 +254,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - service: users-service
-            path: services/users-service
-          - service: accounts-service
-            path: services/accounts-service
-          - service: audit-service
-            path: services/audit-service
-          - service: ledger-service
-            path: ledger-service
+        service: [users-service, accounts-service, audit-service, ledger-service]
     steps:
       - uses: actions/checkout@v4
       - name: Build image
-        working-directory: ${{ matrix.path }}
-        run: docker build -t "${{ matrix.service }}:ci" .
+        run: |
+          if [ "${{ matrix.service }}" = "ledger-service" ]; then
+            if [ -d ledger-service ]; then
+              cd ledger-service
+            else
+              cd services/ledger-service
+            fi
+          else
+            cd "services/${{ matrix.service }}"
+          fi
+          docker build -t "${{ matrix.service }}:ci" .

--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,10 @@ target/
 **/*.rs.bk
 
 # Rails (ledger)
-services/ledger-service/log/
-services/ledger-service/tmp/
-services/ledger-service/storage/
-services/ledger-service/coverage/
+ledger-service/log/
+ledger-service/tmp/
+ledger-service/storage/
+ledger-service/coverage/
 
 # CI / Sonar (Rust LCOV at repo root)
 coverage-rust/

--- a/config/services.json
+++ b/config/services.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "description": "Backend services shipped in this repository (under services/).",
+  "description": "Backend services shipped in this repository.",
   "services": [
     {
       "id": "users-service",
@@ -18,7 +18,7 @@
     },
     {
       "id": "ledger-service",
-      "path": "services/ledger-service",
+      "path": "ledger-service",
       "language": "ruby",
       "summary": "Double-entry ledger, financial finality",
       "ports": { "http": 3000, "grpc": 50053 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     restart: unless-stopped
     working_dir: /app
     volumes:
-      - ./services/ledger-service:/app
+      - ./ledger-service:/app
     environment:
       DATABASE_URL: ${LEDGER_DATABASE_URL}
       RAILS_ENV: development

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,14 +6,14 @@ sonar.projectName=rails-core
 sonar.projectVersion=0.1.0
 
 # Paths are relative to this file. Replace "\" by "/" on Windows.
-sonar.sources=services/users-service,services/accounts-service,services/ledger-service/app,services/ledger-service/lib
+sonar.sources=services/users-service,services/accounts-service,ledger-service/app,ledger-service/lib
 
 # Keep generated artifacts out of analysis.
 sonar.exclusions=**/target/**,**/.sqlx/**,**/vendor/**,**/tmp/**,**/.git/**,coverage-rust/**,**/coverage/**
 
 # Coverage reports (produced in CI before sonar-scanner).
 sonar.rust.lcov.reportPaths=coverage-rust/users.lcov.info,coverage-rust/accounts.lcov.info
-sonar.ruby.coverage.reportPaths=services/ledger-service/coverage/coverage.json
+sonar.ruby.coverage.reportPaths=ledger-service/coverage/coverage.json
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Switch ledger-service path references from `services/ledger-service` to `ledger-service` across CI, compose, Sonar, and service metadata.
- Update Docker build matrix to support per-service paths so only ledger uses the root path while Rust services remain under `services/`.

## Test plan
- [ ] Trigger CI on this branch and confirm ledger jobs resolve `ledger-service` correctly.
- [ ] Verify Railway build no longer errors with missing `/services` directory.