### PR TITLE
fix(ledger): allow Railway hostnames in production host authorization

### DIFF
--- a/services/ledger-service/config/environments/development.rb
+++ b/services/ledger-service/config/environments/development.rb
@@ -68,4 +68,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Railway dev stacks use *.railway.app hostnames; allow them when RAILS_ENV=development on the platform.
+  config.hosts << /\A[\w.-]+\.railway\.app\z/i
 end

--- a/services/ledger-service/config/environments/production.rb
+++ b/services/ledger-service/config/environments/production.rb
@@ -107,8 +107,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # Allow Railway healthcheck hostname for internal health checks
-  config.hosts << "healthcheck.railway.app"
+  # Railway public URLs and healthchecks use *.railway.app (including *.up.railway.app). The BFF and
+  # browsers call the ledger with that Host header; without this entry Rails returns 403 Blocked host.
+  config.hosts << /\A[\w.-]+\.railway\.app\z/i
   
   # Skip DNS rebinding protection for the default health check endpoint.
   # This ensures Railway healthchecks can reach /up even if host authorization is strict


### PR DESCRIPTION
## Root cause
Ledger HTTP returned **403** while JWT auth was fine: Rails **Action Dispatch host authorization** only allowed `healthcheck.railway.app`, so requests whose `Host` was the public service URL (e.g. `*.up.railway.app`) were rejected as **Blocked host** (HTTP 403), unrelated to login.

## Fix
- Whitelist `*.railway.app` in `services/ledger-service/config/environments/production.rb` so Railway public hostnames match `config.hosts`.

## Test plan
- [ ] Deploy ledger to Railway and confirm `GET /api/v1/ledger/entries` with a valid `Authorization` returns **200** (or **401** on bad JWT), not **403**.