### PR TITLE
feat(audit): expose scoped audit event reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ RUST_LOG=info
 # ACCOUNTS_GRPC_URL=http://127.0.0.1:9090
 # USERS_GRPC_URL=http://127.0.0.1:50051
 # LEDGER_GRPC_URL=http://127.0.0.1:50053
+# audit-service uses USERS_GRPC_URL to validate SDK API keys for /api/v1/audit/events.
 
 # Optional — users-service sensitive routes (register/login) require this header when set:
 # INTERNAL_SERVICE_TOKEN_ALLOWLIST=your-dev-token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       AUDIT_DATABASE_URL: ${AUDIT_DATABASE_URL}
       SERVER_ADDR: "0.0.0.0:8080"
       GRPC_PORT: "50054"
+      USERS_GRPC_URL: http://users-service:50051
       RUST_LOG: ${RUST_LOG:-info}
     command: bash -c "export DEBIAN_FRONTEND=noninteractive && apt-get update -qq && apt-get install -y -qq protobuf-compiler curl && cargo run --release"
     expose:

--- a/services/accounts-service/src/models/account.rs
+++ b/services/accounts-service/src/models/account.rs
@@ -54,7 +54,6 @@ pub struct CreateAccountRequest {
     /// Required when creating account for a platform user (legacy). Omit when using holder metadata (email, first_name, last_name).
     #[serde(default)]
     pub user_id: Option<Uuid>,
-    #[serde(default = "default_currency")]
     pub currency: String,
     #[serde(default)]
     pub admin_user_id: Option<Uuid>,  // Required for customer accounts (holder-based or legacy)
@@ -65,10 +64,6 @@ pub struct CreateAccountRequest {
     pub first_name: Option<String>,
     #[serde(default)]
     pub last_name: Option<String>,
-}
-
-fn default_currency() -> String {
-    "USD".to_string()
 }
 
 fn default_environment() -> Option<String> {

--- a/services/audit-service/.env.example
+++ b/services/audit-service/.env.example
@@ -8,6 +8,11 @@ AUDIT_DATABASE_URL=postgresql://user:password@host:5432/audit_db?sslmode=require
 
 SERVER_ADDR=0.0.0.0:8080
 GRPC_PORT=50054
+USERS_GRPC_URL=http://127.0.0.1:50051
+
+# Shared secret for trusted dashboard/BFF reads through rails-client-server.
+AUDIT_SERVICE_INTERNAL_TOKEN=replace_me
+
 RUST_LOG=info
 ENVIRONMENT=development
 

--- a/services/audit-service/build.rs
+++ b/services/audit-service/build.rs
@@ -14,9 +14,17 @@ fn audit_proto_paths(manifest_dir: &Path) -> (PathBuf, PathBuf) {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let manifest_dir = PathBuf::from(std::env::var(CARGO_MANIFEST_DIR_ENV)?);
     let (audit_proto, proto_include) = audit_proto_paths(&manifest_dir);
+    let users_proto_root = manifest_dir.join("proto");
+    let users_proto = users_proto_root.join("users.proto");
+
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(&[audit_proto], &[proto_include])?;
+
+    tonic_build::configure()
+        .build_server(false)
+        .build_client(true)
+        .compile_protos(&[users_proto], &[users_proto_root])?;
     Ok(())
 }

--- a/services/audit-service/proto/users.proto
+++ b/services/audit-service/proto/users.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package rails.users.v1;
+
+option java_multiple_files = true;
+option java_package = "com.rails.users.v1";
+option java_outer_classname = "UsersProto";
+
+service UsersService {
+  rpc ValidateApiKey(ValidateApiKeyRequest) returns (ValidateApiKeyResponse);
+}
+
+message ValidateApiKeyRequest {
+  string api_key = 1;
+  string environment = 2;
+}
+
+message ValidateApiKeyResponse {
+  string business_id = 1;
+  string environment_id = 2;
+  string admin_user_id = 3;
+}

--- a/services/audit-service/src/bootstrap.rs
+++ b/services/audit-service/src/bootstrap.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::prelude::*;
 use crate::config::Config;
 use crate::grpc_server::AuditGrpcService;
 use crate::routes::router;
+use crate::users_grpc::UsersGrpc;
 
 pub async fn run() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
@@ -68,7 +69,8 @@ pub async fn run() -> anyhow::Result<()> {
     let grpc_addr: SocketAddr = ([0, 0, 0, 0], config.grpc_port).into();
 
     let listener = TcpListener::bind(addr).await?;
-    let app = router();
+    let users_grpc = UsersGrpc::connect_lazy(&config.users_grpc_url)?;
+    let app = router(pool.clone(), users_grpc, config.internal_token.clone());
     let grpc_svc = AuditGrpcService::new(pool.clone()).into_server();
 
     let http_task = async move {

--- a/services/audit-service/src/config.rs
+++ b/services/audit-service/src/config.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub database_url: String,
     pub server_addr: String,
     pub grpc_port: u16,
+    pub users_grpc_url: String,
+    pub internal_token: Option<String>,
     pub sentry_dsn: Option<String>,
     pub environment: String,
     pub log_level: String,
@@ -18,6 +20,8 @@ impl Config {
         const DATABASE_URL_ENV: &str = "DATABASE_URL";
         const SERVER_ADDR_ENV: &str = "SERVER_ADDR";
         const GRPC_PORT_ENV: &str = "GRPC_PORT";
+        const USERS_GRPC_URL_ENV: &str = "USERS_GRPC_URL";
+        const AUDIT_SERVICE_INTERNAL_TOKEN_ENV: &str = "AUDIT_SERVICE_INTERNAL_TOKEN";
         const SENTRY_DSN_ENV: &str = "SENTRY_DSN";
         const ENVIRONMENT_ENV: &str = "ENVIRONMENT";
         const RUST_LOG_ENV: &str = "RUST_LOG";
@@ -31,6 +35,12 @@ impl Config {
             .unwrap_or_else(|_| "50054".to_string())
             .parse()
             .context("GRPC_PORT must be a valid u16")?;
+        let users_grpc_url = std::env::var(USERS_GRPC_URL_ENV)
+            .unwrap_or_else(|_| "http://127.0.0.1:50051".to_string());
+        let internal_token = std::env::var(AUDIT_SERVICE_INTERNAL_TOKEN_ENV)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
         let sentry_dsn = std::env::var(SENTRY_DSN_ENV)
             .ok()
             .filter(|s| !s.trim().is_empty());
@@ -41,6 +51,8 @@ impl Config {
             database_url,
             server_addr,
             grpc_port,
+            users_grpc_url,
+            internal_token,
             sentry_dsn,
             environment,
             log_level,

--- a/services/audit-service/src/db.rs
+++ b/services/audit-service/src/db.rs
@@ -2,7 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde_json::Value;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
@@ -27,6 +27,54 @@ pub struct AuditInsert {
     pub correlation_id: String,
     pub reason: Option<String>,
     pub metadata: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuditEventRow {
+    pub id: Uuid,
+    pub occurred_at: DateTime<Utc>,
+    pub schema_version: i16,
+    pub source_service: String,
+    pub organization_id: Uuid,
+    pub environment: String,
+    pub actor_type: String,
+    pub actor_id: String,
+    pub actor_roles: Vec<String>,
+    pub action: String,
+    pub target_type: String,
+    pub target_id: String,
+    pub outcome: String,
+    pub request_id: String,
+    pub request_method: String,
+    pub request_path: String,
+    pub request_ip: String,
+    pub request_user_agent: String,
+    pub correlation_id: String,
+    pub reason: Option<String>,
+    pub metadata: Value,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuditListFilters {
+    pub organization_id: Uuid,
+    pub environment: String,
+    pub action: Option<String>,
+    pub target_type: Option<String>,
+    pub target_id: Option<String>,
+    pub outcome: Option<String>,
+    pub from: Option<DateTime<Utc>>,
+    pub to: Option<DateTime<Utc>>,
+    pub page: u32,
+    pub per_page: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuditPagination {
+    pub page: u32,
+    pub per_page: u32,
+    pub total_count: i64,
+    pub total_pages: u32,
 }
 
 pub async fn insert_audit_event(pool: &PgPool, row: AuditInsert) -> Result<Uuid, sqlx::Error> {
@@ -65,4 +113,109 @@ pub async fn insert_audit_event(pool: &PgPool, row: AuditInsert) -> Result<Uuid,
     .fetch_one(pool)
     .await?;
     Ok(rec)
+}
+
+pub async fn list_audit_events(
+    pool: &PgPool,
+    filters: &AuditListFilters,
+) -> Result<(Vec<AuditEventRow>, AuditPagination), sqlx::Error> {
+    let total_count = count_audit_events(pool, filters).await?;
+    let total_pages = ((total_count as f64) / (filters.per_page as f64)).ceil() as u32;
+    let offset = (filters.page - 1) * filters.per_page;
+
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        r#"
+        SELECT id, occurred_at, schema_version, source_service, organization_id, environment,
+               actor_type, actor_id, actor_roles, action, target_type, target_id, outcome,
+               request_id, request_method, request_path, request_ip, request_user_agent,
+               correlation_id, reason, metadata, created_at
+        FROM audit_events
+        "#,
+    );
+    push_filter_clause(&mut qb, filters);
+    qb.push(" ORDER BY occurred_at DESC, created_at DESC, id DESC LIMIT ");
+    qb.push_bind(filters.per_page as i64);
+    qb.push(" OFFSET ");
+    qb.push_bind(offset as i64);
+
+    let rows = qb.build().fetch_all(pool).await?;
+    let events = rows
+        .iter()
+        .map(row_to_audit_event)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok((
+        events,
+        AuditPagination {
+            page: filters.page,
+            per_page: filters.per_page,
+            total_count,
+            total_pages,
+        },
+    ))
+}
+
+async fn count_audit_events(pool: &PgPool, filters: &AuditListFilters) -> Result<i64, sqlx::Error> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT COUNT(*) FROM audit_events");
+    push_filter_clause(&mut qb, filters);
+    qb.build_query_scalar::<i64>().fetch_one(pool).await
+}
+
+fn push_filter_clause(qb: &mut QueryBuilder<Postgres>, filters: &AuditListFilters) {
+    qb.push(" WHERE organization_id = ");
+    qb.push_bind(filters.organization_id);
+    qb.push(" AND environment = ");
+    qb.push_bind(filters.environment.clone());
+
+    if let Some(action) = &filters.action {
+        qb.push(" AND action = ");
+        qb.push_bind(action.clone());
+    }
+    if let Some(target_type) = &filters.target_type {
+        qb.push(" AND target_type = ");
+        qb.push_bind(target_type.clone());
+    }
+    if let Some(target_id) = &filters.target_id {
+        qb.push(" AND target_id = ");
+        qb.push_bind(target_id.clone());
+    }
+    if let Some(outcome) = &filters.outcome {
+        qb.push(" AND outcome = ");
+        qb.push_bind(outcome.clone());
+    }
+    if let Some(from) = filters.from {
+        qb.push(" AND occurred_at >= ");
+        qb.push_bind(from);
+    }
+    if let Some(to) = filters.to {
+        qb.push(" AND occurred_at <= ");
+        qb.push_bind(to);
+    }
+}
+
+fn row_to_audit_event(row: &sqlx::postgres::PgRow) -> Result<AuditEventRow, sqlx::Error> {
+    Ok(AuditEventRow {
+        id: row.try_get("id")?,
+        occurred_at: row.try_get("occurred_at")?,
+        schema_version: row.try_get("schema_version")?,
+        source_service: row.try_get("source_service")?,
+        organization_id: row.try_get("organization_id")?,
+        environment: row.try_get("environment")?,
+        actor_type: row.try_get("actor_type")?,
+        actor_id: row.try_get("actor_id")?,
+        actor_roles: row.try_get("actor_roles")?,
+        action: row.try_get("action")?,
+        target_type: row.try_get("target_type")?,
+        target_id: row.try_get("target_id")?,
+        outcome: row.try_get("outcome")?,
+        request_id: row.try_get("request_id")?,
+        request_method: row.try_get("request_method")?,
+        request_path: row.try_get("request_path")?,
+        request_ip: row.try_get("request_ip")?,
+        request_user_agent: row.try_get("request_user_agent")?,
+        correlation_id: row.try_get("correlation_id")?,
+        reason: row.try_get("reason")?,
+        metadata: row.try_get("metadata")?,
+        created_at: row.try_get("created_at")?,
+    })
 }

--- a/services/audit-service/src/grpc_server.rs
+++ b/services/audit-service/src/grpc_server.rs
@@ -49,7 +49,7 @@ fn outcome_str(o: Outcome) -> &'static str {
     }
 }
 
-fn event_to_insert(event: &AuditEvent) -> Result<AuditInsert, Status> {
+pub(crate) fn event_to_insert(event: &AuditEvent) -> Result<AuditInsert, Status> {
     let occurred_at: DateTime<Utc> = DateTime::parse_from_rfc3339(&event.occurred_at)
         .map_err(|_| Status::invalid_argument("occurred_at"))?
         .with_timezone(&Utc);
@@ -57,13 +57,24 @@ fn event_to_insert(event: &AuditEvent) -> Result<AuditInsert, Status> {
     let org = Uuid::parse_str(event.organization_id.trim())
         .map_err(|_| Status::invalid_argument("organization_id"))?;
 
-    let actor = event.actor.as_ref().ok_or_else(|| Status::invalid_argument("actor"))?;
-    let actor_type = ActorType::try_from(actor.r#type).map_err(|_| Status::invalid_argument("actor.type"))?;
+    let actor = event
+        .actor
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("actor"))?;
+    let actor_type =
+        ActorType::try_from(actor.r#type).map_err(|_| Status::invalid_argument("actor.type"))?;
 
-    let target = event.target.as_ref().ok_or_else(|| Status::invalid_argument("target"))?;
-    let req = event.request.as_ref().ok_or_else(|| Status::invalid_argument("request"))?;
+    let target = event
+        .target
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("target"))?;
+    let req = event
+        .request
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("request"))?;
 
-    let outcome = Outcome::try_from(event.outcome).map_err(|_| Status::invalid_argument("outcome"))?;
+    let outcome =
+        Outcome::try_from(event.outcome).map_err(|_| Status::invalid_argument("outcome"))?;
 
     let mut meta_map = Map::new();
     for (k, v) in &event.metadata {
@@ -107,7 +118,9 @@ impl AuditService for AuditGrpcService {
         let _txn_guard = txn.clone();
 
         let inner = request.into_inner();
-        let event = inner.event.ok_or_else(|| Status::invalid_argument("event required"))?;
+        let event = inner
+            .event
+            .ok_or_else(|| Status::invalid_argument("event required"))?;
 
         validate_audit_event(&event)?;
 
@@ -182,9 +195,9 @@ mod tests {
         let j = tokio::spawn(serve);
 
         tokio::time::sleep(Duration::from_millis(50)).await;
-        let mut client = crate::proto::proto::audit_service_client::AuditServiceClient::connect(format!(
-            "http://{addr}"
-        ))
+        let mut client = crate::proto::proto::audit_service_client::AuditServiceClient::connect(
+            format!("http://{addr}"),
+        )
         .await
         .unwrap();
 

--- a/services/audit-service/src/lib.rs
+++ b/services/audit-service/src/lib.rs
@@ -6,4 +6,5 @@ pub mod db;
 pub mod grpc_server;
 pub mod proto;
 pub mod routes;
+pub mod users_grpc;
 pub mod validate;

--- a/services/audit-service/src/routes/audit_events.rs
+++ b/services/audit-service/src/routes/audit_events.rs
@@ -1,0 +1,528 @@
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tonic::Code;
+use uuid::Uuid;
+
+use crate::db::{
+    insert_audit_event, list_audit_events as list_audit_events_db, AuditEventRow, AuditListFilters,
+    AuditPagination,
+};
+use crate::grpc_server::event_to_insert;
+use crate::proto::proto::{Actor, ActorType, AuditEvent, Outcome, RequestContext, Target};
+use crate::routes::AppState;
+use crate::validate::validate_audit_event;
+
+type ApiError = (StatusCode, Json<ErrorResponse>);
+type ApiResult<T> = Result<(StatusCode, Json<T>), ApiError>;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorResponse {
+    status: &'static str,
+    code: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AppendAuditEventRequest {
+    event: AuditEventPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditEventPayload {
+    occurred_at: String,
+    schema_version: i32,
+    source_service: String,
+    organization_id: String,
+    environment: String,
+    actor: ActorPayload,
+    action: String,
+    target: TargetPayload,
+    outcome: String,
+    request: RequestContextPayload,
+    correlation_id: String,
+    reason: Option<String>,
+    #[serde(default)]
+    metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActorPayload {
+    #[serde(rename = "type")]
+    actor_type: String,
+    id: String,
+    #[serde(default)]
+    roles: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct TargetPayload {
+    #[serde(rename = "type")]
+    target_type: String,
+    id: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RequestContextPayload {
+    id: String,
+    method: String,
+    path: String,
+    #[serde(default)]
+    ip: String,
+    #[serde(default)]
+    user_agent: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AppendAuditEventResponse {
+    audit_event_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListAuditEventsQuery {
+    organization_id: Option<String>,
+    environment: Option<String>,
+    action: Option<String>,
+    target_type: Option<String>,
+    target_id: Option<String>,
+    outcome: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+    page: Option<u32>,
+    per_page: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListAuditEventsResponse {
+    data: Vec<AuditEventResponse>,
+    pagination: PaginationResponse,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaginationResponse {
+    page: u32,
+    per_page: u32,
+    total_count: i64,
+    total_pages: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuditEventResponse {
+    id: String,
+    occurred_at: String,
+    schema_version: i16,
+    source_service: String,
+    organization_id: String,
+    environment: String,
+    actor: ActorResponse,
+    action: String,
+    target: TargetPayload,
+    outcome: String,
+    request: RequestContextPayload,
+    correlation_id: String,
+    reason: Option<String>,
+    metadata: serde_json::Value,
+    created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ActorResponse {
+    #[serde(rename = "type")]
+    actor_type: String,
+    id: String,
+    roles: Vec<String>,
+}
+
+pub async fn append_audit_event(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<AppendAuditEventRequest>,
+) -> ApiResult<AppendAuditEventResponse> {
+    let internal_token = header_value(&headers, "x-internal-service-token").ok_or_else(|| {
+        api_error(
+            StatusCode::UNAUTHORIZED,
+            "UNAUTHORIZED",
+            "X-Internal-Service-Token header is required",
+        )
+    })?;
+    let expected = state.internal_token.as_deref().ok_or_else(|| {
+        api_error(
+            StatusCode::UNAUTHORIZED,
+            "UNAUTHORIZED",
+            "Internal audit append is not configured",
+        )
+    })?;
+    if internal_token != expected {
+        return Err(api_error(
+            StatusCode::UNAUTHORIZED,
+            "UNAUTHORIZED",
+            "Invalid internal service token",
+        ));
+    }
+
+    if let Some(environment) = header_value(&headers, "x-environment")
+        .map(|value| normalize_environment(Some(&value)))
+        .transpose()?
+    {
+        if request.event.environment.trim().to_lowercase() != environment {
+            return Err(api_error(
+                StatusCode::BAD_REQUEST,
+                "VALIDATION_FAILED",
+                "event.environment must match X-Environment",
+            ));
+        }
+    }
+
+    if Uuid::parse_str(request.event.organization_id.trim()).is_err() {
+        return Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "organization_id must be a UUID",
+        ));
+    }
+
+    let event = request.event.into_proto()?;
+    validate_audit_event(&event).map_err(map_tonic_validation_error)?;
+    let row = event_to_insert(&event).map_err(map_tonic_validation_error)?;
+    let id = insert_audit_event(&state.pool, row).await.map_err(|e| {
+        tracing::error!(error = %e, "failed to insert SDK audit event");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL",
+            "Failed to append audit event",
+        )
+    })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AppendAuditEventResponse {
+            audit_event_id: id.to_string(),
+        }),
+    ))
+}
+
+pub async fn list_audit_events(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<ListAuditEventsQuery>,
+) -> ApiResult<ListAuditEventsResponse> {
+    let (organization_id, environment) = resolve_list_scope(&state, &headers, &query).await?;
+    let filters = build_list_filters(organization_id, environment, query)?;
+
+    let (rows, pagination) = list_audit_events_db(&state.pool, &filters)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to list audit events");
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL",
+                "Failed to list audit events",
+            )
+        })?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ListAuditEventsResponse {
+            data: rows.into_iter().map(AuditEventResponse::from).collect(),
+            pagination: PaginationResponse::from(pagination),
+        }),
+    ))
+}
+
+async fn resolve_list_scope(
+    state: &AppState,
+    headers: &HeaderMap,
+    query: &ListAuditEventsQuery,
+) -> Result<(Uuid, String), ApiError> {
+    if let Some(internal_token) = header_value(headers, "x-internal-service-token") {
+        let expected = state.internal_token.as_deref().ok_or_else(|| {
+            api_error(
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHORIZED",
+                "Internal audit reads are not configured",
+            )
+        })?;
+        if internal_token != expected {
+            return Err(api_error(
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHORIZED",
+                "Invalid internal service token",
+            ));
+        }
+
+        let organization_id = query
+            .organization_id
+            .as_deref()
+            .ok_or_else(|| {
+                api_error(
+                    StatusCode::BAD_REQUEST,
+                    "VALIDATION_FAILED",
+                    "organization_id query parameter is required",
+                )
+            })
+            .and_then(parse_uuid)?;
+        let environment = normalize_environment(query.environment.as_deref())?;
+        return Ok((organization_id, environment));
+    }
+
+    let environment = query
+        .environment
+        .as_deref()
+        .map(|s| normalize_environment(Some(s)))
+        .transpose()?
+        .or_else(|| header_value(headers, "x-environment"))
+        .map(|s| normalize_environment(Some(&s)))
+        .transpose()?
+        .unwrap_or_else(|| "sandbox".to_string());
+
+    let api_key = header_value(headers, "x-api-key").ok_or_else(|| {
+        api_error(
+            StatusCode::UNAUTHORIZED,
+            "UNAUTHORIZED",
+            "X-API-Key header is required",
+        )
+    })?;
+
+    let (business_id, _environment_id, _admin_user_id) = state
+        .users_grpc
+        .validate_api_key(&api_key, &environment)
+        .await
+        .map_err(map_users_grpc_error)?;
+
+    Ok((business_id, environment))
+}
+
+fn build_list_filters(
+    organization_id: Uuid,
+    environment: String,
+    query: ListAuditEventsQuery,
+) -> Result<AuditListFilters, ApiError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(25).clamp(1, 100);
+    let outcome = optional_trimmed(query.outcome)
+        .map(validate_outcome_filter)
+        .transpose()?;
+
+    Ok(AuditListFilters {
+        organization_id,
+        environment,
+        action: optional_trimmed(query.action),
+        target_type: optional_trimmed(query.target_type),
+        target_id: optional_trimmed(query.target_id),
+        outcome,
+        from: query.from.as_deref().map(parse_rfc3339).transpose()?,
+        to: query.to.as_deref().map(parse_rfc3339).transpose()?,
+        page,
+        per_page,
+    })
+}
+
+impl AuditEventPayload {
+    fn into_proto(self) -> Result<AuditEvent, ApiError> {
+        Ok(AuditEvent {
+            occurred_at: self.occurred_at,
+            schema_version: self.schema_version,
+            source_service: self.source_service,
+            organization_id: self.organization_id,
+            environment: self.environment,
+            actor: Some(Actor {
+                r#type: parse_actor_type(&self.actor.actor_type)? as i32,
+                id: self.actor.id,
+                roles: self.actor.roles,
+            }),
+            action: self.action,
+            target: Some(Target {
+                r#type: self.target.target_type,
+                id: self.target.id,
+            }),
+            outcome: parse_outcome(&self.outcome)? as i32,
+            request: Some(RequestContext {
+                id: self.request.id,
+                method: self.request.method,
+                path: self.request.path,
+                ip: self.request.ip,
+                user_agent: self.request.user_agent,
+            }),
+            correlation_id: self.correlation_id,
+            reason: self.reason,
+            metadata: self.metadata,
+        })
+    }
+}
+
+impl From<AuditEventRow> for AuditEventResponse {
+    fn from(row: AuditEventRow) -> Self {
+        Self {
+            id: row.id.to_string(),
+            occurred_at: row.occurred_at.to_rfc3339(),
+            schema_version: row.schema_version,
+            source_service: row.source_service,
+            organization_id: row.organization_id.to_string(),
+            environment: row.environment,
+            actor: ActorResponse {
+                actor_type: row.actor_type,
+                id: row.actor_id,
+                roles: row.actor_roles,
+            },
+            action: row.action,
+            target: TargetPayload {
+                target_type: row.target_type,
+                id: row.target_id,
+            },
+            outcome: row.outcome,
+            request: RequestContextPayload {
+                id: row.request_id,
+                method: row.request_method,
+                path: row.request_path,
+                ip: row.request_ip,
+                user_agent: row.request_user_agent,
+            },
+            correlation_id: row.correlation_id,
+            reason: row.reason,
+            metadata: row.metadata,
+            created_at: row.created_at.to_rfc3339(),
+        }
+    }
+}
+
+impl From<AuditPagination> for PaginationResponse {
+    fn from(pagination: AuditPagination) -> Self {
+        Self {
+            page: pagination.page,
+            per_page: pagination.per_page,
+            total_count: pagination.total_count,
+            total_pages: pagination.total_pages,
+        }
+    }
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn optional_trimmed(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn parse_uuid(value: &str) -> Result<Uuid, ApiError> {
+    Uuid::parse_str(value.trim()).map_err(|_| {
+        api_error(
+            StatusCode::BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "organization_id must be a UUID",
+        )
+    })
+}
+
+fn normalize_environment(value: Option<&str>) -> Result<String, ApiError> {
+    match value.map(|s| s.trim().to_lowercase()).as_deref() {
+        Some("sandbox") => Ok("sandbox".to_string()),
+        Some("production") => Ok("production".to_string()),
+        _ => Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "environment must be 'sandbox' or 'production'",
+        )),
+    }
+}
+
+fn validate_outcome_filter(value: String) -> Result<String, ApiError> {
+    match value.as_str() {
+        "success" | "client_error" | "server_error" => Ok(value),
+        _ => Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "outcome must be one of: success, client_error, server_error",
+        )),
+    }
+}
+
+fn parse_rfc3339(value: &str) -> Result<DateTime<Utc>, ApiError> {
+    DateTime::parse_from_rfc3339(value.trim())
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|_| {
+            api_error(
+                StatusCode::BAD_REQUEST,
+                "VALIDATION_FAILED",
+                "from and to must be RFC3339 timestamps",
+            )
+        })
+}
+
+fn parse_actor_type(value: &str) -> Result<ActorType, (StatusCode, Json<ErrorResponse>)> {
+    match value.trim() {
+        "user" => Ok(ActorType::User),
+        "api_key" => Ok(ActorType::ApiKey),
+        "internal_service" => Ok(ActorType::InternalService),
+        "anonymous" => Ok(ActorType::Anonymous),
+        _ => Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "actor.type must be one of: user, api_key, internal_service, anonymous",
+        )),
+    }
+}
+
+fn parse_outcome(value: &str) -> Result<Outcome, (StatusCode, Json<ErrorResponse>)> {
+    match value.trim() {
+        "success" => Ok(Outcome::Success),
+        "client_error" => Ok(Outcome::ClientError),
+        "server_error" => Ok(Outcome::ServerError),
+        _ => Err(api_error(
+            StatusCode::BAD_REQUEST,
+            "VALIDATION_FAILED",
+            "outcome must be one of: success, client_error, server_error",
+        )),
+    }
+}
+
+fn map_users_grpc_error(status: tonic::Status) -> (StatusCode, Json<ErrorResponse>) {
+    match status.code() {
+        Code::Unauthenticated | Code::InvalidArgument => {
+            api_error(StatusCode::UNAUTHORIZED, "UNAUTHORIZED", status.message())
+        }
+        Code::PermissionDenied => api_error(StatusCode::FORBIDDEN, "FORBIDDEN", status.message()),
+        _ => {
+            tracing::error!(error = %status, "users-service API key validation failed");
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL",
+                "Failed to validate API key",
+            )
+        }
+    }
+}
+
+fn map_tonic_validation_error(status: tonic::Status) -> (StatusCode, Json<ErrorResponse>) {
+    api_error(
+        StatusCode::BAD_REQUEST,
+        "VALIDATION_FAILED",
+        status.message(),
+    )
+}
+
+fn api_error(
+    status: StatusCode,
+    code: &'static str,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        status,
+        Json(ErrorResponse {
+            status: "error",
+            code,
+            message: message.into(),
+        }),
+    )
+}

--- a/services/audit-service/src/routes/mod.rs
+++ b/services/audit-service/src/routes/mod.rs
@@ -1,9 +1,32 @@
-//! HTTP routes (health only in v1).
+//! HTTP routes for service health and SDK-public audit ingest.
 
+mod audit_events;
 mod health;
 
-use axum::Router;
+use axum::{routing::get, Router};
+use sqlx::PgPool;
 
-pub fn router() -> Router {
-    Router::new().route("/health", axum::routing::get(health::health_check))
+use crate::users_grpc::UsersGrpc;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub pool: PgPool,
+    pub users_grpc: UsersGrpc,
+    pub internal_token: Option<String>,
+}
+
+pub fn router(pool: PgPool, users_grpc: UsersGrpc, internal_token: Option<String>) -> Router {
+    let state = AppState {
+        pool,
+        users_grpc,
+        internal_token,
+    };
+
+    Router::new()
+        .route("/health", axum::routing::get(health::health_check))
+        .route(
+            "/api/v1/audit/events",
+            get(audit_events::list_audit_events).post(audit_events::append_audit_event),
+        )
+        .with_state(state)
 }

--- a/services/audit-service/src/users_grpc.rs
+++ b/services/audit-service/src/users_grpc.rs
@@ -1,0 +1,53 @@
+//! gRPC client for users-service API key validation.
+
+use tonic::transport::{Channel, Endpoint};
+use uuid::Uuid;
+
+pub mod users_proto {
+    tonic::include_proto!("rails.users.v1");
+}
+
+use users_proto::users_service_client::UsersServiceClient;
+
+#[derive(Clone)]
+pub struct UsersGrpc {
+    client: UsersServiceClient<Channel>,
+}
+
+impl UsersGrpc {
+    /// Create a lazy gRPC client so audit-service startup does not depend on users-service readiness.
+    pub fn connect_lazy(url: &str) -> anyhow::Result<Self> {
+        let channel = Endpoint::from_shared(url.to_string())
+            .map_err(|e| anyhow::anyhow!("Invalid USERS_GRPC_URL: {}", e))?
+            .connect_lazy();
+        Ok(Self {
+            client: UsersServiceClient::new(channel),
+        })
+    }
+
+    pub async fn validate_api_key(
+        &self,
+        api_key: &str,
+        environment: &str,
+    ) -> Result<(Uuid, Uuid, Uuid), tonic::Status> {
+        let req = users_proto::ValidateApiKeyRequest {
+            api_key: api_key.to_string(),
+            environment: environment.to_string(),
+        };
+        let res = self
+            .client
+            .clone()
+            .validate_api_key(tonic::Request::new(req))
+            .await?;
+        let body = res.into_inner();
+
+        let business_id = Uuid::parse_str(&body.business_id)
+            .map_err(|_| tonic::Status::internal("invalid business_id from users service"))?;
+        let environment_id = Uuid::parse_str(&body.environment_id)
+            .map_err(|_| tonic::Status::internal("invalid environment_id from users service"))?;
+        let admin_user_id = Uuid::parse_str(&body.admin_user_id)
+            .map_err(|_| tonic::Status::internal("invalid admin_user_id from users service"))?;
+
+        Ok((business_id, environment_id, admin_user_id))
+    }
+}

--- a/services/audit-service/src/validate.rs
+++ b/services/audit-service/src/validate.rs
@@ -83,7 +83,9 @@ fn validate_occurred_at(event: &AuditEvent) -> Result<(), Status> {
         .with_timezone(&Utc);
 
     if occurred_at > Utc::now() + chrono::Duration::minutes(5) {
-        return Err(Status::invalid_argument("occurred_at cannot be far in the future"));
+        return Err(Status::invalid_argument(
+            "occurred_at cannot be far in the future",
+        ));
     }
     Ok(())
 }
@@ -140,7 +142,10 @@ fn validate_outcome(event: &AuditEvent) -> Result<(), Status> {
 }
 
 fn validate_actor(event: &AuditEvent) -> Result<(), Status> {
-    let actor = event.actor.as_ref().ok_or_else(|| Status::invalid_argument("actor is required"))?;
+    let actor = event
+        .actor
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("actor is required"))?;
     let actor_type = ActorType::try_from(actor.r#type)
         .map_err(|_| Status::invalid_argument("invalid actor type"))?;
     if actor_type == ActorType::Unspecified {
@@ -155,7 +160,9 @@ fn validate_target(event: &AuditEvent) -> Result<(), Status> {
         .as_ref()
         .ok_or_else(|| Status::invalid_argument("target is required"))?;
     if target.r#type.trim().is_empty() || target.id.trim().is_empty() {
-        return Err(Status::invalid_argument("target.type and target.id are required"));
+        return Err(Status::invalid_argument(
+            "target.type and target.id are required",
+        ));
     }
     Ok(())
 }
@@ -166,7 +173,9 @@ fn validate_request(event: &AuditEvent) -> Result<(), Status> {
         .as_ref()
         .ok_or_else(|| Status::invalid_argument("request is required"))?;
     if req.method.trim().is_empty() || req.path.trim().is_empty() {
-        return Err(Status::invalid_argument("request.method and request.path are required"));
+        return Err(Status::invalid_argument(
+            "request.method and request.path are required",
+        ));
     }
     Ok(())
 }
@@ -184,14 +193,20 @@ fn validate_reason(event: &AuditEvent) -> Result<(), Status> {
 fn validate_metadata(event: &AuditEvent) -> Result<(), Status> {
     let allowed_meta = static_metadata_keys();
     if event.metadata.len() > 16 {
-        return Err(Status::invalid_argument("metadata may have at most 16 entries"));
+        return Err(Status::invalid_argument(
+            "metadata may have at most 16 entries",
+        ));
     }
     for (k, v) in &event.metadata {
         if !allowed_meta.contains(k.as_str()) {
-            return Err(Status::invalid_argument("metadata key not allowlisted for v1"));
+            return Err(Status::invalid_argument(
+                "metadata key not allowlisted for v1",
+            ));
         }
         if v.chars().count() > 256 {
-            return Err(Status::invalid_argument("metadata value exceeds 256 characters"));
+            return Err(Status::invalid_argument(
+                "metadata value exceeds 256 characters",
+            ));
         }
     }
     Ok(())
@@ -270,8 +285,7 @@ mod tests {
     fn rejects_metadata_value_too_long() {
         let mut e = base_event();
         e.organization_id = Uuid::new_v4().to_string();
-        e.metadata
-            .insert("http_status".into(), "x".repeat(257));
+        e.metadata.insert("http_status".into(), "x".repeat(257));
         assert!(validate_audit_event(&e).is_err());
     }
 }

--- a/services/audit-service/tests/append_persist_e2e.rs
+++ b/services/audit-service/tests/append_persist_e2e.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 
 use audit_service::grpc_server::AuditGrpcService;
 use audit_service::proto::proto::audit_service_client::AuditServiceClient;
+use audit_service::proto::proto::ActorType;
 use audit_service::proto::proto::{
     Actor, AppendAuditEventRequest, AuditEvent, Outcome, RequestContext, Target,
 };
-use audit_service::proto::proto::ActorType;
 use chrono::Utc;
 use sqlx::migrate::Migrator;
 use sqlx::postgres::PgPoolOptions;
@@ -28,10 +28,7 @@ async fn append_audit_event_persists_row() {
         .await
         .expect("start postgres (requires Docker for testcontainers)");
     let host = container.get_host().await.expect("host");
-    let port = container
-        .get_host_port_ipv4(5432)
-        .await
-        .expect("port");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
     let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
 
     let pool = PgPoolOptions::new()
@@ -52,12 +49,9 @@ async fn append_audit_event_persists_row() {
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let serve = Server::builder()
         .add_service(server)
-        .serve_with_incoming_shutdown(
-            TcpListenerStream::new(listener),
-            async {
-                let _ = shutdown_rx.await;
-            },
-        );
+        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+            let _ = shutdown_rx.await;
+        });
     let join = tokio::spawn(serve);
     tokio::time::sleep(Duration::from_millis(500)).await;
 

--- a/services/ledger-service/app/grpc/ledger_service.rb
+++ b/services/ledger-service/app/grpc/ledger_service.rb
@@ -16,7 +16,8 @@ class LedgerService < Rails::Ledger::V1::LedgerService::Service
     source_external_account_id = raw_source.to_s
     destination_external_account_id = raw_dest.to_s
     amount = request.amount
-    currency = normalize_currency(request.currency.to_s)
+    raw_currency = request.currency.to_s
+    currency = raw_currency.strip.empty? ? '' : normalize_currency(raw_currency)
     external_transaction_id = request.external_transaction_id.to_s
     idempotency_key = request.idempotency_key.to_s
     correlation_id = request.correlation_id.to_s

--- a/services/ledger-service/app/grpc/ledger_service.rb
+++ b/services/ledger-service/app/grpc/ledger_service.rb
@@ -16,7 +16,7 @@ class LedgerService < Rails::Ledger::V1::LedgerService::Service
     source_external_account_id = raw_source.to_s
     destination_external_account_id = raw_dest.to_s
     amount = request.amount
-    currency = request.currency.to_s
+    currency = normalize_currency(request.currency.to_s)
     external_transaction_id = request.external_transaction_id.to_s
     idempotency_key = request.idempotency_key.to_s
     correlation_id = request.correlation_id.to_s
@@ -86,7 +86,7 @@ class LedgerService < Rails::Ledger::V1::LedgerService::Service
     organization_id = request.organization_id
     environment = proto_env_to_string(request.environment)
     external_account_id = request.external_account_id
-    currency = request.currency
+    currency = normalize_currency(request.currency.to_s)
 
     Rails.logger.info "[LEDGER_GRPC] get_account_balance START org=#{organization_id} env=#{environment} account=#{external_account_id} currency=#{currency}"
 
@@ -120,7 +120,7 @@ class LedgerService < Rails::Ledger::V1::LedgerService::Service
     environment = proto_env_to_string(request.environment)
     from_external_account_id = request.from_external_account_id
     to_external_account_id = request.to_external_account_id
-    currency = request.currency
+    currency = normalize_currency(request.currency.to_s)
 
     Rails.logger.info "[LEDGER_GRPC] get_account_balances START org=#{organization_id} env=#{environment} from=#{from_external_account_id} to=#{to_external_account_id} currency=#{currency}"
 
@@ -165,6 +165,13 @@ class LedgerService < Rails::Ledger::V1::LedgerService::Service
   end
 
   private
+
+  def normalize_currency(raw_currency)
+    normalized = raw_currency.strip.upcase
+    return Rails.configuration.x.default_currency if normalized.empty?
+
+    normalized
+  end
 
   def proto_env_to_string(proto_env)
     # Ruby protobuf enum fields can come through as Symbols (e.g. :SANDBOX)

--- a/services/ledger-service/app/services/ledger_poster.rb
+++ b/services/ledger-service/app/services/ledger_poster.rb
@@ -113,7 +113,7 @@ class LedgerPoster
   def validate_inputs!
     raise PostingError, "Amount must be positive" unless @amount > 0
     raise PostingError, "Invalid environment" unless %w[sandbox production].include?(@environment)
-    raise PostingError, "Currency is required" unless @currency.present?
+    raise PostingError, "Currency is required" if @currency.blank?
     raise PostingError, "Currency must be a 3-letter ISO code" unless @currency.match?(/\A[A-Z]{3}\z/)
   end
 

--- a/services/ledger-service/app/services/ledger_poster.rb
+++ b/services/ledger-service/app/services/ledger_poster.rb
@@ -40,7 +40,7 @@ class LedgerPoster
     @source_external_account_id = source_external_account_id
     @destination_external_account_id = destination_external_account_id
     @amount = amount
-    @currency = currency
+    @currency = currency.to_s.strip.upcase
     @external_transaction_id = external_transaction_id
     @idempotency_key = idempotency_key
     @correlation_id = correlation_id
@@ -113,7 +113,8 @@ class LedgerPoster
   def validate_inputs!
     raise PostingError, "Amount must be positive" unless @amount > 0
     raise PostingError, "Invalid environment" unless %w[sandbox production].include?(@environment)
-    raise PostingError, "Currency must match" unless @currency.present?
+    raise PostingError, "Currency is required" unless @currency.present?
+    raise PostingError, "Currency must be a 3-letter ISO code" unless @currency.match?(/\A[A-Z]{3}\z/)
   end
 
   def existing_result(transaction)

--- a/services/ledger-service/config/application.rb
+++ b/services/ledger-service/config/application.rb
@@ -44,5 +44,7 @@ module Ledger
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.x.default_currency = ENV.fetch('LEDGER_DEFAULT_CURRENCY', 'USD').upcase
   end
 end

--- a/services/users-service/src/routes/apikey.rs
+++ b/services/users-service/src/routes/apikey.rs
@@ -3,32 +3,32 @@ use std::net::SocketAddr;
 
 use axum::extract::ConnectInfo;
 use axum::http::HeaderMap;
-use axum::{Json, extract::State, extract::Path};
+use axum::{extract::Path, extract::State, Json};
 use uuid::Uuid;
 
 use crate::audit_emit;
+use crate::auth::{hash_api_key, AuthContext};
+use crate::error::AppError;
 use crate::grpc::audit_proto::ActorType;
-use crate::{error::AppError};
 use crate::routes::AppState;
-use crate::auth::{AuthContext, hash_api_key};
-use serde::{Deserialize, Serialize};
-use chrono::Utc;
-use sqlx::Row;
-use rand::rngs::OsRng;
-use rand::rand_core::TryRngCore;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL_ENGINE;
 use base64::Engine;
+use chrono::Utc;
+use rand::rand_core::TryRngCore;
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
 
 #[derive(Deserialize)]
 pub struct CreateApiKeyRequest {
-    pub environment_id: Option<Uuid>
+    pub environment_id: Option<Uuid>,
 }
 
 #[derive(Serialize)]
 pub struct CreateApiKeyResponse {
     pub id: Uuid,
     pub key: String,
-    pub status: String
+    pub status: String,
 }
 
 #[derive(Serialize)]
@@ -50,13 +50,15 @@ async fn create_api_key_inner(
 ) -> Result<(CreateApiKeyResponse, Uuid, Uuid), AppError> {
     let request_user_id = ctx.user_id.ok_or(AppError::Forbidden)?;
 
-    let role_row = sqlx::query("SELECT role FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'")
-        .bind(&request_user_id)
-        .bind(&ctx.environment_id)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|_| AppError::Internal)?
-        .ok_or(AppError::Forbidden)?;
+    let role_row = sqlx::query(
+        "SELECT role FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'",
+    )
+    .bind(&request_user_id)
+    .bind(&ctx.environment_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|_| AppError::Internal)?
+    .ok_or(AppError::Forbidden)?;
 
     let role: String = role_row.get("role");
     if role != "admin" {
@@ -65,7 +67,7 @@ async fn create_api_key_inner(
 
     if let Some(env_id) = payload.environment_id {
         let env_ok = sqlx::query(
-            "SELECT 1 FROM environments WHERE id = $1 AND business_id = $2 AND status = 'active'"
+            "SELECT 1 FROM environments WHERE id = $1 AND business_id = $2 AND status = 'active'",
         )
         .bind(&env_id)
         .bind(&ctx.business_id)
@@ -175,13 +177,15 @@ pub async fn list_api_keys(
     ctx: AuthContext,
 ) -> Result<Json<Vec<ApiKeyInfo>>, AppError> {
     let request_user_id = ctx.user_id.ok_or(AppError::Forbidden)?;
-    let role_row = sqlx::query("SELECT role FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'")
-        .bind(&request_user_id)
-        .bind(&ctx.environment_id)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|_| AppError::Internal)?
-        .ok_or(AppError::Forbidden)?;
+    let role_row = sqlx::query(
+        "SELECT role FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'",
+    )
+    .bind(&request_user_id)
+    .bind(&ctx.environment_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|_| AppError::Internal)?
+    .ok_or(AppError::Forbidden)?;
 
     let role: String = role_row.get("role");
     if role != "admin" {
@@ -219,13 +223,15 @@ async fn revoke_api_key_inner(
     Path(api_key_id): Path<Uuid>,
 ) -> Result<(CreateApiKeyResponse, Uuid, Uuid), AppError> {
     let request_user_id = ctx.user_id.ok_or(AppError::Forbidden)?;
-    let role_row = sqlx::query("SELECT role FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'")
-        .bind(&request_user_id)
-        .bind(&ctx.environment_id)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|_| AppError::Internal)?
-        .ok_or(AppError::Forbidden)?;
+    let role_row = sqlx::query(
+        "SELECT role FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'",
+    )
+    .bind(&request_user_id)
+    .bind(&ctx.environment_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|_| AppError::Internal)?
+    .ok_or(AppError::Forbidden)?;
 
     let role: String = role_row.get("role");
     if role != "admin" {
@@ -244,7 +250,9 @@ async fn revoke_api_key_inner(
     .map_err(|_| AppError::Internal)?;
 
     if result.rows_affected() == 0 {
-        return Err(AppError::BadRequest("API key not found or already revoked".to_string()));
+        return Err(AppError::BadRequest(
+            "API key not found or already revoked".to_string(),
+        ));
     }
 
     Ok((

--- a/services/users-service/src/routes/auth.rs
+++ b/services/users-service/src/routes/auth.rs
@@ -3,15 +3,15 @@ use std::net::SocketAddr;
 
 use axum::extract::ConnectInfo;
 use axum::http::HeaderMap;
-use axum::{Json, extract::State};
+use axum::{extract::State, Json};
 
 use crate::audit_emit;
+use crate::error::AppError;
 use crate::grpc::audit_proto::ActorType;
+use crate::routes::{user, AppState};
 use argon2::password_hash::rand_core::OsRng;
 use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 use base64::engine::Engine;
-use crate::error::AppError;
-use crate::routes::{AppState, user};
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 
@@ -67,11 +67,11 @@ pub struct RevokeTokenResponse {
     pub status: String,
 }
 
+use argon2::password_hash::{rand_core::RngCore, PasswordHash, PasswordVerifier};
+use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey, Header};
-use argon2::password_hash::{PasswordHash, PasswordVerifier, rand_core::RngCore};
-use chrono::{Utc, Duration};
-use uuid::Uuid;
 use serde_json::json;
+use uuid::Uuid;
 
 async fn login_inner(
     state: AppState,
@@ -100,16 +100,23 @@ async fn login_inner(
     // 2. Verify password
     let parsed_hash = PasswordHash::new(&password_hash).map_err(|e| {
         let user_id: Uuid = user_rows[0].get("id");
-        tracing::error!("Failed to parse password hash for user_id {}: {}", user_id, e);
+        tracing::error!(
+            "Failed to parse password hash for user_id {}: {}",
+            user_id,
+            e
+        );
         AppError::Internal
     })?;
-    if argon2::Argon2::default().verify_password(payload.password.as_bytes(), &parsed_hash).is_err() {
+    if argon2::Argon2::default()
+        .verify_password(payload.password.as_bytes(), &parsed_hash)
+        .is_err()
+    {
         return Err(AppError::Unauthorized);
     }
 
     // Get business_id from first user (all users with same email should have same business_id)
     let business_id: Uuid = user_rows[0].get("business_id");
-    
+
     // Get ALL environments for the business (not just where user exists)
     // This allows users to see both sandbox and production environments
     let environments = sqlx::query(
@@ -183,8 +190,12 @@ async fn login_inner(
     });
     const JWT_SECRET_ENV: &str = "JWT_SECRET";
     let secret = std::env::var(JWT_SECRET_ENV).unwrap_or_else(|_| "dev_secret".to_string());
-    let access_token = encode(&Header::default(), &claims, &EncodingKey::from_secret(secret.as_bytes()))
-        .map_err(|_| AppError::Internal)?;
+    let access_token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|_| AppError::Internal)?;
 
     // 4. Generate refresh token
     let mut refresh_bytes = [0u8; 32];
@@ -301,20 +312,18 @@ async fn refresh_token_inner(
     let environment_id: Uuid = rec.get("environment_id");
     let status: String = rec.get("status");
     let expires_at: chrono::DateTime<Utc> = rec.get("expires_at");
-    
+
     if status != "active" || expires_at < Utc::now() {
         return Err(AppError::Unauthorized);
     }
 
     // Get business_id for JWT
-    let business_row = sqlx::query(
-        "SELECT business_id FROM users WHERE id = $1"
-    )
-    .bind(&user_id)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|_| AppError::Internal)?
-    .ok_or(AppError::Internal)?;
+    let business_row = sqlx::query("SELECT business_id FROM users WHERE id = $1")
+        .bind(&user_id)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|_| AppError::Internal)?
+        .ok_or(AppError::Internal)?;
     let business_id: Uuid = business_row.get("business_id");
 
     // 2. Issue new JWT
@@ -331,8 +340,12 @@ async fn refresh_token_inner(
     });
     const JWT_SECRET_ENV: &str = "JWT_SECRET";
     let secret = std::env::var(JWT_SECRET_ENV).unwrap_or_else(|_| "dev_secret".to_string());
-    let access_token = encode(&Header::default(), &claims, &EncodingKey::from_secret(secret.as_bytes()))
-        .map_err(|_| AppError::Internal)?;
+    let access_token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .map_err(|_| AppError::Internal)?;
 
     // 3. Issue new refresh token and update session
     let mut refresh_bytes = [0u8; 32];
@@ -344,14 +357,12 @@ async fn refresh_token_inner(
 
     // Revoke old session and insert new
     let mut tx = state.db.begin().await.map_err(|_| AppError::Internal)?;
-    sqlx::query(
-        "UPDATE user_sessions SET status = 'revoked', revoked_at = $1 WHERE id = $2"
-    )
-    .bind(&now)
-    .bind(&session_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|_| AppError::Internal)?;
+    sqlx::query("UPDATE user_sessions SET status = 'revoked', revoked_at = $1 WHERE id = $2")
+        .bind(&now)
+        .bind(&session_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|_| AppError::Internal)?;
     sqlx::query(
         "INSERT INTO user_sessions (id, user_id, environment_id, refresh_token, jwt_id, status, created_at, expires_at) VALUES ($1, $2, $3, $4, $5, 'active', $6, $7)"
     )
@@ -448,9 +459,8 @@ async fn revoke_token_inner(
     .fetch_optional(&state.db)
     .await
     .map_err(|_| AppError::Internal)?;
-    let row = row.ok_or_else(|| {
-        AppError::BadRequest("Token not found or already revoked".to_string())
-    })?;
+    let row =
+        row.ok_or_else(|| AppError::BadRequest("Token not found or already revoked".to_string()))?;
     let user_id: Uuid = row.get("user_id");
     let business_id: Uuid = row.get("business_id");
 

--- a/services/users-service/src/routes/beta.rs
+++ b/services/users-service/src/routes/beta.rs
@@ -42,9 +42,7 @@ fn normalize_payload(payload: BetaApplicationRequest) -> Result<BetaApplicationI
     let use_case = payload.use_case.trim();
 
     if name.is_empty() || email.is_empty() || company.is_empty() || use_case.is_empty() {
-        return Err(AppError::BadRequest(
-            "All fields are required.".to_string(),
-        ));
+        return Err(AppError::BadRequest("All fields are required.".to_string()));
     }
 
     Ok(BetaApplicationInput {
@@ -67,7 +65,7 @@ async fn apply_for_beta_inner(
 
     // Application-level duplicate check (defense in depth with DB constraint)
     let exists = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS(SELECT 1 FROM beta_applications WHERE LOWER(TRIM(email)) = $1)"
+        "SELECT EXISTS(SELECT 1 FROM beta_applications WHERE LOWER(TRIM(email)) = $1)",
     )
     .bind(&email_normalized)
     .fetch_one(&state.db)
@@ -102,7 +100,12 @@ async fn apply_for_beta_inner(
 
     if let Some(email_service) = &state.email {
         if let Err(error) = email_service
-            .send_beta_application(&input.name, &email_normalized, &input.company, &input.use_case)
+            .send_beta_application(
+                &input.name,
+                &email_normalized,
+                &input.company,
+                &input.use_case,
+            )
             .await
         {
             tracing::error!("Failed to send beta application email: {}", error);
@@ -295,13 +298,12 @@ mod tests {
             "Application received. We'll be in touch shortly."
         );
 
-        let count: i64 = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM beta_applications WHERE email = $1"
-        )
-        .bind(&applicant_email)
-        .fetch_one(&pool)
-        .await
-        .expect("Failed to query beta applications");
+        let count: i64 =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM beta_applications WHERE email = $1")
+                .bind(&applicant_email)
+                .fetch_one(&pool)
+                .await
+                .expect("Failed to query beta applications");
 
         assert_eq!(count, 1);
         resend_mock.assert_async().await;
@@ -357,13 +359,12 @@ mod tests {
             "Application received. We'll be in touch shortly."
         );
 
-        let count: i64 = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM beta_applications WHERE email = $1"
-        )
-        .bind(&applicant_email)
-        .fetch_one(&pool)
-        .await
-        .expect("Failed to query beta applications");
+        let count: i64 =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM beta_applications WHERE email = $1")
+                .bind(&applicant_email)
+                .fetch_one(&pool)
+                .await
+                .expect("Failed to query beta applications");
 
         assert_eq!(count, 1);
     }

--- a/services/users-service/src/routes/business.rs
+++ b/services/users-service/src/routes/business.rs
@@ -3,21 +3,21 @@ use std::net::SocketAddr;
 
 use axum::extract::ConnectInfo;
 use axum::http::HeaderMap;
-use axum::{Json, extract::State};
+use axum::{extract::State, Json};
 use uuid::Uuid;
 
 use crate::audit_emit;
-use crate::grpc::audit_proto::ActorType;
-use chrono::{Utc, Duration};
 use crate::error::{AppError, DUPLICATE_EMAIL_MESSAGE};
-use crate::routes::{AppState, user};
-use serde::{Deserialize, Serialize};
-use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::{SaltString, rand_core::OsRng};
+use crate::grpc::audit_proto::ActorType;
+use crate::routes::{user, AppState};
 use argon2::password_hash::rand_core::RngCore;
+use argon2::password_hash::{rand_core::OsRng, SaltString};
+use argon2::{Argon2, PasswordHasher};
 use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 use base64::engine::Engine;
+use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 #[derive(Deserialize)]
@@ -27,7 +27,7 @@ pub struct RegisterBusinessRequest {
     pub admin_first_name: String,
     pub admin_last_name: String,
     pub admin_email: String,
-    pub admin_password: String
+    pub admin_password: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -45,7 +45,7 @@ pub struct RegisterBusinessResponse {
 #[derive(Debug, Serialize)]
 pub struct EnvironmentInfo {
     pub id: Uuid,
-    pub r#type: String
+    pub r#type: String,
 }
 
 async fn register_business_inner(
@@ -58,13 +58,12 @@ async fn register_business_inner(
     }
 
     // Application-level check before insert (defense in depth with DB constraint)
-    let exists = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)"
-    )
-    .bind(&admin_email_normalized)
-    .fetch_one(&state.db)
-    .await
-    .map_err(|_| AppError::Internal)?;
+    let exists =
+        sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)")
+            .bind(&admin_email_normalized)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|_| AppError::Internal)?;
     if exists {
         return Err(AppError::Conflict(DUPLICATE_EMAIL_MESSAGE.to_string()));
     }
@@ -313,7 +312,11 @@ mod tests {
             Json(payload),
         )
         .await;
-        assert!(result.is_ok(), "Unique email registration should succeed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Unique email registration should succeed: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]
@@ -356,7 +359,10 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         if let AppError::Conflict(msg) = err {
-            assert_eq!(msg, DUPLICATE_EMAIL_MESSAGE, "Error message should be stable and user-friendly");
+            assert_eq!(
+                msg, DUPLICATE_EMAIL_MESSAGE,
+                "Error message should be stable and user-friendly"
+            );
         } else {
             panic!("Expected Conflict, got {:?}", err);
         }
@@ -399,8 +405,15 @@ mod tests {
             Json(payload2),
         )
         .await;
-        assert!(result.is_err(), "Case-insensitive duplicate should be blocked");
+        assert!(
+            result.is_err(),
+            "Case-insensitive duplicate should be blocked"
+        );
         let err = result.unwrap_err();
-        assert!(matches!(err, AppError::Conflict(_)), "Expected Conflict for case variant: {:?}", err);
+        assert!(
+            matches!(err, AppError::Conflict(_)),
+            "Expected Conflict for case variant: {:?}",
+            err
+        );
     }
 }

--- a/services/users-service/src/routes/mod.rs
+++ b/services/users-service/src/routes/mod.rs
@@ -1,26 +1,29 @@
-pub mod business;
 pub mod apikey;
-pub mod user;
 pub mod auth;
+pub mod beta;
+pub mod business;
 pub mod health;
 pub mod password_reset;
-pub mod beta;
+pub mod user;
 
 mod rate_limit;
 
-use axum::{Router, routing::{post, get}};
+use crate::db::Db;
+use crate::email::EmailService;
+use crate::error::AppError;
+use crate::grpc::GrpcClients;
 use axum::body::Body;
 use axum::http::Request;
 use axum::middleware::{from_fn, Next};
 use axum::response::Response;
-use crate::db::Db;
-use crate::grpc::GrpcClients;
-use crate::error::AppError;
-use crate::email::EmailService;
+use axum::{
+    routing::{get, post},
+    Router,
+};
 use rate_limit::{extract_client_key, RateLimitConfig, RateLimiter};
-use uuid::Uuid;
 use std::sync::OnceLock;
 use std::time::Duration;
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -33,14 +36,23 @@ pub fn register_routes(db: Db, grpc: GrpcClients, email: Option<EmailService>) -
     let state = AppState { db, grpc, email };
     let public = Router::new()
         .route("/health", get(health::health_check))
-        .route("/api/v1/business/register", post(business::register_business))
+        .route(
+            "/api/v1/business/register",
+            post(business::register_business),
+        )
         .route("/api/v1/auth/refresh", post(auth::refresh_token))
         .route("/api/v1/auth/revoke", post(auth::revoke_token));
 
     let auth_limited = Router::new()
         .route("/api/v1/auth/login", post(auth::login))
-        .route("/api/v1/auth/password-reset/request", post(password_reset::request_password_reset))
-        .route("/api/v1/auth/password-reset/reset", post(password_reset::reset_password))
+        .route(
+            "/api/v1/auth/password-reset/request",
+            post(password_reset::request_password_reset),
+        )
+        .route(
+            "/api/v1/auth/password-reset/reset",
+            post(password_reset::reset_password),
+        )
         .route("/api/v1/beta/apply", post(beta::apply_for_beta))
         .layer(from_fn(auth_rate_limit_middleware));
 
@@ -48,13 +60,18 @@ pub fn register_routes(db: Db, grpc: GrpcClients, email: Option<EmailService>) -
     let protected = Router::new()
         .route("/api/v1/api-keys", post(apikey::create_api_key))
         .route("/api/v1/api-keys", get(apikey::list_api_keys))
-        .route("/api/v1/api-keys/:api_key_id/revoke", post(apikey::revoke_api_key))
-        .route("/api/v1/users", post(user::create_sdk_user))
+        .route(
+            "/api/v1/api-keys/:api_key_id/revoke",
+            post(apikey::revoke_api_key),
+        )
         .route("/api/v1/me", get(user::me));
+
+    let sdk_public = Router::new().route("/api/v1/users", post(user::create_sdk_user));
 
     public
         .merge(auth_limited)
         .merge(protected)
+        .merge(sdk_public)
         .layer(from_fn(correlation_id_middleware))
         .layer(from_fn(internal_caller_middleware))
         .with_state(state)
@@ -158,9 +175,7 @@ async fn correlation_id_middleware(req: Request<Body>, next: Next) -> Result<Res
     if should_set_header {
         req.headers_mut().insert(
             "x-correlation-id",
-            correlation_id
-                .parse()
-                .map_err(|_| AppError::Internal)?,
+            correlation_id.parse().map_err(|_| AppError::Internal)?,
         );
     }
 
@@ -170,9 +185,7 @@ async fn correlation_id_middleware(req: Request<Body>, next: Next) -> Result<Res
     let mut res = next.run(req).await;
     res.headers_mut().insert(
         "x-correlation-id",
-        correlation_id
-            .parse()
-            .map_err(|_| AppError::Internal)?,
+        correlation_id.parse().map_err(|_| AppError::Internal)?,
     );
     let status = res.status().as_u16();
     let duration_ms = start.elapsed().as_millis();
@@ -250,8 +263,12 @@ mod tests {
             .header("x-forwarded-for", "203.0.113.10")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
-        assert_eq!(extract_client_key(&req, USERS_TRUSTED_PROXY_IPS), "127.0.0.1");
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
+        assert_eq!(
+            extract_client_key(&req, USERS_TRUSTED_PROXY_IPS),
+            "127.0.0.1"
+        );
     }
 
     #[test]
@@ -263,8 +280,12 @@ mod tests {
             .header("x-forwarded-for", "203.0.113.10, 127.0.0.1")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
-        assert_eq!(extract_client_key(&req, USERS_TRUSTED_PROXY_IPS), "203.0.113.10");
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
+        assert_eq!(
+            extract_client_key(&req, USERS_TRUSTED_PROXY_IPS),
+            "203.0.113.10"
+        );
     }
     #[test]
     fn log_correlation_request_finished_covers_status_branches() {
@@ -286,7 +307,11 @@ mod tests {
             .header("x-forwarded-for", "203.0.113.10, 198.51.100.5")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
-        assert_eq!(extract_client_key(&req, USERS_TRUSTED_PROXY_IPS), "127.0.0.1");
+        req.extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
+        assert_eq!(
+            extract_client_key(&req, USERS_TRUSTED_PROXY_IPS),
+            "127.0.0.1"
+        );
     }
 }

--- a/services/users-service/src/routes/password_reset.rs
+++ b/services/users-service/src/routes/password_reset.rs
@@ -6,22 +6,25 @@ use std::net::SocketAddr;
 
 use axum::extract::ConnectInfo;
 use axum::http::HeaderMap;
-use axum::{Json, extract::State};
+use axum::{extract::State, Json};
 
 use crate::audit_emit;
 use crate::grpc::audit_proto::ActorType;
+use argon2::password_hash::{
+    rand_core::{OsRng, RngCore},
+    SaltString,
+};
 use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::{rand_core::{OsRng, RngCore}, SaltString};
-use chrono::{Utc, Duration};
-use uuid::Uuid;
-use serde::{Deserialize, Serialize};
-use sqlx::Row;
-use sha2::{Sha256, Digest};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64_ENGINE;
 use base64::Engine;
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::Row;
+use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::routes::{AppState, user};
+use crate::routes::{user, AppState};
 
 #[derive(Deserialize)]
 pub struct RequestPasswordResetRequest {
@@ -55,16 +58,15 @@ async fn request_password_reset_inner(
 ) -> Result<(RequestPasswordResetResponse, PasswordResetRequestOutcome), AppError> {
     // Always return success to prevent user enumeration
     // This is a security best practice
-    
+
     // Find user by email (only active users); normalize for case-insensitive lookup
     let email_normalized = user::normalize_email(&payload.email);
-    let user_row = sqlx::query(
-        "SELECT id FROM users WHERE email = $1 AND status = 'active' LIMIT 1"
-    )
-    .bind(&email_normalized)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|_| AppError::Internal)?;
+    let user_row =
+        sqlx::query("SELECT id FROM users WHERE email = $1 AND status = 'active' LIMIT 1")
+            .bind(&email_normalized)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|_| AppError::Internal)?;
 
     // If user doesn't exist, still return success (no enumeration)
     let user_id: Uuid = match user_row {
@@ -73,8 +75,9 @@ async fn request_password_reset_inner(
             tracing::info!("Password reset requested for non-existent account");
             return Ok((
                 RequestPasswordResetResponse {
-                    message: "If an account exists with that email, a password reset link has been sent."
-                        .to_string(),
+                    message:
+                        "If an account exists with that email, a password reset link has been sent."
+                            .to_string(),
                 },
                 PasswordResetRequestOutcome::NoSuchUser,
             ));
@@ -99,7 +102,7 @@ async fn request_password_reset_inner(
     // Invalidate all previous reset tokens for this user
     // This ensures only the latest token is usable
     sqlx::query(
-        "UPDATE password_reset_tokens SET used_at = $1 WHERE user_id = $2 AND used_at IS NULL"
+        "UPDATE password_reset_tokens SET used_at = $1 WHERE user_id = $2 AND used_at IS NULL",
     )
     .bind(&now)
     .bind(&user_id)
@@ -124,9 +127,15 @@ async fn request_password_reset_inner(
 
     // Send email (best-effort, don't fail if email fails)
     if let Some(email_service) = &state.email {
-        match email_service.send_password_reset(&payload.email, &raw_token).await {
+        match email_service
+            .send_password_reset(&payload.email, &raw_token)
+            .await
+        {
             Ok(_) => {
-                tracing::info!("Password reset email sent successfully to {}", payload.email);
+                tracing::info!(
+                    "Password reset email sent successfully to {}",
+                    payload.email
+                );
             }
             Err(e) => {
                 // Log error but don't fail the request
@@ -147,7 +156,8 @@ async fn request_password_reset_inner(
 
     Ok((
         RequestPasswordResetResponse {
-            message: "If an account exists with that email, a password reset link has been sent.".to_string(),
+            message: "If an account exists with that email, a password reset link has been sent."
+                .to_string(),
         },
         PasswordResetRequestOutcome::Issued {
             user_id,
@@ -170,18 +180,16 @@ pub async fn request_password_reset(
     match request_password_reset_inner(state.clone(), Json(payload)).await {
         Ok((body, outcome)) => {
             let (org, actor, actor_id, tgt) = match &outcome {
-                PasswordResetRequestOutcome::NoSuchUser => {
-                    (Uuid::nil(), ActorType::Anonymous, String::default(), Uuid::nil())
-                }
+                PasswordResetRequestOutcome::NoSuchUser => (
+                    Uuid::nil(),
+                    ActorType::Anonymous,
+                    String::default(),
+                    Uuid::nil(),
+                ),
                 PasswordResetRequestOutcome::Issued {
                     user_id,
                     business_id,
-                } => (
-                    *business_id,
-                    ActorType::User,
-                    user_id.to_string(),
-                    *user_id,
-                ),
+                } => (*business_id, ActorType::User, user_id.to_string(), *user_id),
             };
             audit_emit::emit_users_mutation(
                 &state.grpc,
@@ -280,7 +288,9 @@ async fn reset_password_inner(
 
     // Validate password strength (minimum 8 characters)
     if payload.new_password.len() < 8 {
-        return Err(AppError::BadRequest("Password must be at least 8 characters long".to_string()));
+        return Err(AppError::BadRequest(
+            "Password must be at least 8 characters long".to_string(),
+        ));
     }
 
     // Hash new password
@@ -295,17 +305,19 @@ async fn reset_password_inner(
 
     // Atomically claim the token inside the transaction to prevent races
     let token_row = sqlx::query(claim_token_sql())
-    .bind(&Utc::now())
-    .bind(&token_hash)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|_| AppError::Internal)?;
+        .bind(&Utc::now())
+        .bind(&token_hash)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|_| AppError::Internal)?;
 
     let (token_id, user_id): (Uuid, Uuid) = match token_row {
         Some(row) => (row.get("id"), row.get("user_id")),
         None => {
             // Generic error - don't reveal if token doesn't exist, expired, or already used
-            return Err(AppError::BadRequest("Invalid or expired reset token".to_string()));
+            return Err(AppError::BadRequest(
+                "Invalid or expired reset token".to_string(),
+            ));
         }
     };
 
@@ -317,15 +329,13 @@ async fn reset_password_inner(
     let business_id: Uuid = business_row.get("business_id");
 
     // Update user password
-    sqlx::query(
-        "UPDATE users SET password_hash = $1, updated_at = $2 WHERE id = $3"
-    )
-    .bind(&password_hash)
-    .bind(&Utc::now())
-    .bind(&user_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|_| AppError::Internal)?;
+    sqlx::query("UPDATE users SET password_hash = $1, updated_at = $2 WHERE id = $3")
+        .bind(&password_hash)
+        .bind(&Utc::now())
+        .bind(&user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|_| AppError::Internal)?;
 
     // Invalidate all other reset tokens for this user (security: single-use)
     sqlx::query(
@@ -340,11 +350,11 @@ async fn reset_password_inner(
 
     // Revoke all active sessions for this user to invalidate refresh tokens
     sqlx::query(revoke_user_sessions_sql())
-    .bind(&Utc::now())
-    .bind(&user_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|_| AppError::Internal)?;
+        .bind(&Utc::now())
+        .bind(&user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|_| AppError::Internal)?;
 
     tx.commit().await.map_err(|_| AppError::Internal)?;
 
@@ -352,7 +362,9 @@ async fn reset_password_inner(
 
     Ok((
         ResetPasswordResponse {
-            message: "Password has been reset successfully. You can now log in with your new password.".to_string(),
+            message:
+                "Password has been reset successfully. You can now log in with your new password."
+                    .to_string(),
         },
         user_id,
         business_id,

--- a/services/users-service/src/routes/rate_limit.rs
+++ b/services/users-service/src/routes/rate_limit.rs
@@ -34,7 +34,10 @@ impl RateLimiter {
         let now = Instant::now();
         let entry = store
             .entry(client_key.to_string())
-            .or_insert(RateLimitWindow { start: now, count: 0 });
+            .or_insert(RateLimitWindow {
+                start: now,
+                count: 0,
+            });
 
         if now.duration_since(entry.start) > self.config.window {
             entry.start = now;
@@ -52,7 +55,10 @@ impl RateLimiter {
     /// Clears all clients (used by unit tests; production uses process restart).
     #[cfg(test)]
     pub fn reset(&self) {
-        self.store.lock().expect("rate limiter lock poisoned").clear();
+        self.store
+            .lock()
+            .expect("rate limiter lock poisoned")
+            .clear();
     }
 }
 
@@ -172,9 +178,11 @@ mod tests {
             .header("x-real-ip", "198.51.100.33")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(axum::extract::ConnectInfo(
-            std::net::SocketAddr::from(([127, 0, 0, 1], 8080)),
-        ));
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                8080,
+            ))));
         assert_eq!(
             extract_client_key(&req, USERS_TRUSTED_PROXY_IPS),
             "198.51.100.33"
@@ -190,9 +198,11 @@ mod tests {
             .header("x-forwarded-for", " , 203.0.113.10 , 127.0.0.1 ")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(axum::extract::ConnectInfo(
-            std::net::SocketAddr::from(([127, 0, 0, 1], 8080)),
-        ));
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                8080,
+            ))));
         assert_eq!(
             extract_client_key(&req, USERS_TRUSTED_PROXY_IPS),
             "203.0.113.10"
@@ -234,9 +244,6 @@ mod tests {
             .uri("/api/v1/auth/login")
             .body(Body::empty())
             .unwrap();
-        assert_eq!(
-            extract_client_key(&req, USERS_TRUSTED_PROXY_IPS),
-            "unknown"
-        );
+        assert_eq!(extract_client_key(&req, USERS_TRUSTED_PROXY_IPS), "unknown");
     }
 }

--- a/services/users-service/src/routes/user.rs
+++ b/services/users-service/src/routes/user.rs
@@ -6,7 +6,7 @@ use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use axum::extract::ConnectInfo;
 use axum::http::HeaderMap;
-use axum::{Json, extract::State};
+use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use uuid::Uuid;
@@ -77,11 +77,12 @@ async fn create_sdk_user_inner(
         &payload.password,
     )?;
 
-    let exists = sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)")
-        .bind(&email)
-        .fetch_one(&state.db)
-        .await
-        .map_err(|_| AppError::Internal)?;
+    let exists =
+        sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)")
+            .bind(&email)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|_| AppError::Internal)?;
     if exists {
         return Err(AppError::Conflict(DUPLICATE_EMAIL_MESSAGE.to_string()));
     }
@@ -229,7 +230,7 @@ pub async fn me(
     ctx: AuthContext,
 ) -> Result<Json<MeResponse>, AppError> {
     let user_id = ctx.user_id.ok_or(AppError::Forbidden)?;
-    
+
     // First, try to find user in the requested environment
     let user_row = sqlx::query(
         "SELECT id, business_id, environment_id, first_name, last_name, email, role, status FROM users WHERE id = $1 AND environment_id = $2 AND status = 'active'"
@@ -239,7 +240,7 @@ pub async fn me(
     .fetch_optional(&state.db)
     .await
     .map_err(|_| AppError::Internal)?;
-    
+
     // If user doesn't exist in requested environment, find them in any environment for the same business
     // This allows users to access both sandbox and production even if they only have a user record in one
     let user_row = if let Some(row) = user_row {
@@ -254,7 +255,7 @@ pub async fn me(
         .fetch_optional(&state.db)
         .await
         .map_err(|_| AppError::Internal)?;
-        
+
         // Verify that the requested environment_id belongs to the same business
         if any_user_row.is_some() {
             let env_check = sqlx::query(
@@ -265,15 +266,15 @@ pub async fn me(
             .fetch_optional(&state.db)
             .await
             .map_err(|_| AppError::Internal)?;
-            
+
             if env_check.is_none() {
                 return Err(AppError::Forbidden);
             }
         }
-        
+
         any_user_row
     };
-    
+
     let user_row = user_row.ok_or(AppError::Forbidden)?;
 
     let user = MeUser {
@@ -304,7 +305,7 @@ pub async fn me(
     };
 
     let business_row = sqlx::query(
-        "SELECT id, name, website, status FROM businesses WHERE id = $1 AND status = 'active'"
+        "SELECT id, name, website, status FROM businesses WHERE id = $1 AND status = 'active'",
     )
     .bind(&user.business_id)
     .fetch_optional(&state.db)
@@ -341,11 +342,13 @@ mod tests {
     #[test]
     fn duplicate_email_message_is_user_friendly_and_stable() {
         assert!(
-            DUPLICATE_EMAIL_MESSAGE.contains("account") && DUPLICATE_EMAIL_MESSAGE.contains("email"),
+            DUPLICATE_EMAIL_MESSAGE.contains("account")
+                && DUPLICATE_EMAIL_MESSAGE.contains("email"),
             "Message should be non-technical and actionable"
         );
         assert!(
-            DUPLICATE_EMAIL_MESSAGE.contains("signing in") || DUPLICATE_EMAIL_MESSAGE.contains("reset"),
+            DUPLICATE_EMAIL_MESSAGE.contains("signing in")
+                || DUPLICATE_EMAIL_MESSAGE.contains("reset"),
             "Message should suggest sign in or password reset"
         );
     }


### PR DESCRIPTION
## Summary
- add tenant-scoped audit event listing in audit-service
- keep audit append internal/system-only
- wire users API key validation for SDK audit reads

## Validation
- cargo test in services/audit-service
- cargo check in services/users-service