### PR TITLE
fix(dev): correct ledger local paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,5 @@ dev: bootstrap
 	@echo "Starting Docker Compose in the background (first run may compile Rust/Ruby for many minutes)."
 	@echo "Containers will restart on failure; gateway starts after app healthchecks pass."
 	@cd "$(REPO_ROOT)" && docker compose --env-file .env up -d --build
+	@cd "$(REPO_ROOT)" && docker compose --env-file .env restart gateway >/dev/null
 	@RAILS_CORE_ROOT="$(REPO_ROOT)" python3 "$(RAILS_CORE)scripts/lib/wait_for_stack.py"

--- a/config/services.json
+++ b/config/services.json
@@ -18,7 +18,7 @@
     },
     {
       "id": "ledger-service",
-      "path": "ledger-service",
+      "path": "services/ledger-service",
       "language": "ruby",
       "summary": "Double-entry ledger, financial finality",
       "ports": { "http": 3000, "grpc": 50053 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     restart: unless-stopped
     working_dir: /app
     volumes:
-      - ./ledger-service:/app
+      - ./services/ledger-service:/app
     environment:
       DATABASE_URL: ${LEDGER_DATABASE_URL}
       RAILS_ENV: development


### PR DESCRIPTION
Summary:
- point service metadata at services/ledger-service
- mount the tracked ledger app path in docker-compose
- restart the gateway after make dev rebuilds the stack so local routing picks up the current service layout

Validation:
- docker compose --env-file .env config --quiet
- python3 -m json.tool config/services.json