### PR TITLE
fix(accounts-service): return durable retry metadata on claim/status updates

### DIFF
--- a/services/accounts-service/src/repositories/transaction_repository.rs
+++ b/services/accounts-service/src/repositories/transaction_repository.rs
@@ -275,10 +275,14 @@ impl TransactionRepository {
         let row = sqlx::query(
             r#"
             UPDATE transactions
-            SET status = 'posting', failure_reason = NULL, updated_at = NOW()
+            SET status = 'posting',
+                failure_reason = NULL,
+                retry_count = COALESCE(retry_count, 0) + 1,
+                last_attempted_at = NOW(),
+                updated_at = NOW()
             WHERE id = $1 AND status = 'pending'
             RETURNING id, organization_id, from_account_id, to_account_id, amount, currency,
-                      transaction_kind, status, failure_reason, idempotency_key, environment, description, external_recipient_id, reference_id, created_at, updated_at
+                      transaction_kind, status, failure_reason, idempotency_key, environment, description, external_recipient_id, reference_id, retry_count, last_attempted_at, next_retry_at, terminal_failure_at, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -428,7 +432,7 @@ impl TransactionRepository {
             SET status = $2, failure_reason = $3, updated_at = NOW()
             WHERE id = $1
             RETURNING id, organization_id, from_account_id, to_account_id, amount, currency,
-                      transaction_kind, status, failure_reason, idempotency_key, environment, description, external_recipient_id, reference_id, created_at, updated_at
+                      transaction_kind, status, failure_reason, idempotency_key, environment, description, external_recipient_id, reference_id, retry_count, last_attempted_at, next_retry_at, terminal_failure_at, created_at, updated_at
             "#,
         )
         .bind(id)

--- a/services/accounts-service/tests/http_money_mutations.rs
+++ b/services/accounts-service/tests/http_money_mutations.rs
@@ -312,7 +312,10 @@ fn assert_deferred_payload_contract(body: &serde_json::Value) -> String {
         .get("retry_count")
         .and_then(|v| v.as_i64())
         .expect("202 response must include retry_count");
-    assert_eq!(retry_count, 0);
+    assert!(
+        retry_count >= 1,
+        "retry_count must reflect at least one posting attempt"
+    );
     let next_retry_at = body
         .get("next_retry_at")
         .expect("202 response must include next_retry_at");

--- a/services/accounts-service/tests/postgres_transaction_posting/try_claim.rs
+++ b/services/accounts-service/tests/postgres_transaction_posting/try_claim.rs
@@ -23,6 +23,10 @@ async fn try_claim_pending_then_none_when_not_pending() {
         .unwrap()
         .unwrap();
     assert_eq!(claimed.status, TransactionStatus::Posting);
+    assert_eq!(claimed.retry_count, 1);
+    assert!(claimed.last_attempted_at.is_some());
+    assert!(claimed.next_retry_at.is_none());
+    assert!(claimed.terminal_failure_at.is_none());
 
     let second = TransactionRepository::try_claim_pending_for_post(&pool, id)
         .await

--- a/services/accounts-service/tests/postgres_transaction_posting/update_status.rs
+++ b/services/accounts-service/tests/postgres_transaction_posting/update_status.rs
@@ -18,6 +18,13 @@ async fn update_status_can_set_posting() {
     )
     .await;
 
+    let claimed = TransactionRepository::try_claim_pending_for_post(&pool, id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.retry_count, 1);
+    assert!(claimed.last_attempted_at.is_some());
+
     let updated = TransactionRepository::update_status(
         &pool,
         id,
@@ -27,4 +34,6 @@ async fn update_status_can_set_posting() {
     .await
     .unwrap();
     assert_eq!(updated.status, TransactionStatus::Posting);
+    assert_eq!(updated.retry_count, 1);
+    assert!(updated.last_attempted_at.is_some());
 }


### PR DESCRIPTION
## Summary
- ensure direct pending-to-posting claims increment and return durable retry metadata
- include retry metadata fields in `update_status` return payload
- add regression tests for claim and status transition metadata visibility

## Validation
- cargo test --test postgres_transaction_posting -- --nocapture